### PR TITLE
EMBCDFA-1048: Update file upload box messaging

### DIFF
--- a/dfa-public/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.html
@@ -17,7 +17,7 @@
   <p class="file-format">Restricted characters in file name:</p>
   <p class="invalid-characters">
     ~ " # % & * : . &lt; &gt; ? / &#123; | &#125;. Leading and trailing spaces
-    in file name aren't allowed.
+    in file name aren't allowed. The maximum file size is 25MB.
   </p>
 </div>
 <div *ngIf="attachSizeError" style="color: red">

--- a/dfa-public/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.scss
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.scss
@@ -1,5 +1,5 @@
 .drag-drop {
-  height: 230px;
+  height: 250px;
   padding: 2rem;
   text-align: center;
   border: dashed 1px #C4C4C4;

--- a/dfa-public/src/UI/embc-dfa/src/app/core/services/globalConstants.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/services/globalConstants.ts
@@ -227,7 +227,7 @@ export const fileTooLargeMessage = 'Attachment file size must not be more than 2
 export const fileTypeMessage = 'Invalid file type.';
 export const fileNameFormat = /^[\w,\s-_()]+\.[A-Za-z]{3,4}$/;
 export const invalidFileNameMessage =
-  'File name must not contain the following characters: ~ " . # % & * : < > ? /  { | }. Leading and trailing spaces are not allowed.';
+  'File name must not contain the following characters: ~ " . # % & * : < > ? /  { | }. Leading and trailing spaces are not allowed. The maximum file size is 25MB.';
   export const allowedFileTypes = [
     'application/pdf',
     'image/jpg',

--- a/dfa/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.html
+++ b/dfa/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.html
@@ -17,7 +17,7 @@
   <p class="file-format">Restricted characters in file name:</p>
   <p class="invalid-characters">
     ~ " # % & * : . &lt; &gt; ? / &#123; | &#125;. Leading and trailing spaces
-    in file name aren't allowed.
+    in file name aren't allowed. The maximum file size is 25MB.
   </p>
 </div>
 <div *ngIf="attachSizeError" style="color: red">

--- a/dfa/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.scss
+++ b/dfa/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.scss
@@ -1,5 +1,5 @@
 .drag-drop {
-  height: 230px;
+  height: 250px;
   padding: 2rem;
   text-align: center;
   border: dashed 1px #C4C4C4;

--- a/dfa/src/UI/embc-dfa/src/app/core/services/globalConstants.ts
+++ b/dfa/src/UI/embc-dfa/src/app/core/services/globalConstants.ts
@@ -221,7 +221,7 @@ export const fileTooLargeMessage = 'Attachment file size must not be more than 2
 export const fileTypeMessage = 'Invalid file type.';
 export const fileNameFormat = /^[\w,\s-_()]+\.[A-Za-z]{3,4}$/;
 export const invalidFileNameMessage =
-  'File name must not contain the following characters: ~ " . # % & * : < > ? /  { | }. Leading and trailing spaces are not allowed.';
+  'File name must not contain the following characters: ~ " . # % & * : < > ? /  { | }. Leading and trailing spaces are not allowed. The maximum file size is 25MB.';
   export const allowedFileTypes = [
     'application/pdf',
     'image/jpg',


### PR DESCRIPTION
Issue: https://jag.gov.bc.ca/jira/browse/EMBCDFA-1048?filter=-1

If a citizen is trying to upload a file that is too big and keeps getting the error below they may not realize that the problem is the file size and instead think the portal is constantly having problems. 

Need to review where/when this message may display and whether the message can be more targeted or contain more details. 