### PR TITLE
EMBCDFA-1288: Portal 90 Day Deadline Fix

### DIFF
--- a/dfa/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
+++ b/dfa/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
@@ -739,7 +739,7 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                 {
                     var lstActiveEvents = lstEvents.List.Where(m => m.statuscode == "1").ToList();
 
-                    var deadline90days = lstActiveEvents.Where(m => m.dfa_90daydeadlinenew != null && Convert.ToDateTime(m.dfa_90daydeadlinenew) >= DateTime.Now).Count();
+                    var deadline90days = lstActiveEvents.Where(m => m.dfa_90daydeadlinenew != null && Convert.ToDateTime(m.dfa_90daydeadlinenew) >= DateTime.Today).Count();
                     if (deadline90days > 0)
                     {
                         return deadline90days;
@@ -767,7 +767,7 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                     }
                 });
 
-                var nowDate = DateTime.Now;
+                var nowDate = DateTime.Today;
                 // open events are those active events where the 90 day deadline is now or in the future
                 return lstEvents.List.Where(m => m.dfa_90daydeadlinenew != null && Convert.ToDateTime(m.dfa_90daydeadlinenew) >= nowDate && m.statuscode == "1");
             }

--- a/dfa/src/UI/embc-dfa/proxy.dev.conf.json
+++ b/dfa/src/UI/embc-dfa/proxy.dev.conf.json
@@ -1,41 +1,41 @@
 {
   "/api/**": {
-    "target": "https://dfa-portal-dev.apps.silver.devops.gov.bc.ca",
+    "target": "https://portal.dev.dfa.gov.bc.ca",
     "secure": false,
     "changeOrigin": true,
     "logLevel": "debug"
   },
   "/login": {
-    "target": "https://dfa-portal-dev.apps.silver.devops.gov.bc.ca",
+    "target": "https://portal.dev.dfa.gov.bc.ca",
     "secure": false,
     "changeOrigin": true,
     "logLevel": "debug"
   },
   "/token": {
-    "target": "https://dfa-portal-dev.apps.silver.devops.gov.bc.ca",
+    "target": "https://portal.dev.dfa.gov.bc.ca",
     "secure": false,
     "changeOrigin": true,
     "logLevel": "debug"
   },
   "/signin-oidc": {
-    "target": "https://dfa-portal-dev.apps.silver.devops.gov.bc.ca",
+    "target": "https://portal.dev.dfa.gov.bc.ca",
     "secure": false,
     "changeOrigin": true,
     "logLevel": "debug"
   },
   "/join": {
-    "target": "https://dfa-portal-dev.apps.silver.devops.gov.bc.ca",
+    "target": "https://portal.dev.dfa.gov.bc.ca",
     "secure": false,
     "logLevel": "debug"
   },
   "/env/info.json": {
-    "target": "https://dfa-portal-dev.apps.silver.devops.gov.bc.ca",
+    "target": "https://portal.dev.dfa.gov.bc.ca",
     "secure": false,
     "changeOrigin": true,
     "logLevel": "debug"
   },
   "/version": {
-    "target": "https://dfa-portal-dev.apps.silver.devops.gov.bc.ca",
+    "target": "https://portal.dev.dfa.gov.bc.ca",
     "secure": false,
     "changeOrigin": true,
     "logLevel": "debug"

--- a/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.ts
@@ -282,7 +282,7 @@ export class DFAApplicationMainComponent
           this.ninetyDayDeadline = value;
           let date = new Date(value);
           let currentDate = new Date();
-          this.daysToApply = Math.floor((date.getTime() - currentDate.getTime()) / 1000 / 60 / 60 / 24);
+          this.daysToApply = Math.floor((date.getTime() - currentDate.getTime()) / 1000 / 60 / 60 / 24) + 2; // Account for start and end dates
         }
       })
   }

--- a/dfa/src/UI/embc-dfa/src/app/sharedModules/dashboard-components/dfa-events/dfa-events.component.html
+++ b/dfa/src/UI/embc-dfa/src/app/sharedModules/dashboard-components/dfa-events/dfa-events.component.html
@@ -16,7 +16,7 @@
         </div>
         <div class="col-4" style="text-align: center">
           <span><b>Submit before midnight on:</b>&nbsp;&nbsp;{{eventItem.ninetyDayDeadline | date: "dd-MMM-yyyy"}}</span> <br />
-          <span><b style="color: #990000">{{ eventItem.remainingDays }} days remaining to apply</b></span>
+          <span><b style="color: #990000">{{ getRemainingDays(eventItem) }}</b></span>
         </div>
       </div><br/><br/>
       <table mat-table [dataSource]="getEffectedRegionCommuntiesForEvent(eventItem.eventId)" style="width:100%" *ngIf="getEffectedRegionCommuntiesForEvent(eventItem.eventId).length>0">

--- a/dfa/src/UI/embc-dfa/src/app/sharedModules/dashboard-components/dfa-events/dfa-events.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/sharedModules/dashboard-components/dfa-events/dfa-events.component.ts
@@ -36,6 +36,14 @@ export class DfaEventsComponent implements OnInit {
     });
   }
 
+  getRemainingDays(event: DisasterEvent): string {
+    const remainingDays = Number(event.remainingDays) + 2; // Account for start and end dates
+    if (remainingDays === 1) {
+      return "Apply by midnight tonight";
+    }
+    return `${remainingDays} days remaining to apply`;
+  }
+
   getEffectedRegionCommunities() {
     this.eligibilityService.eligibilityGetRegionCommunties().subscribe((effectedRegionCommunities: EffectedRegionCommunity[]) => {
       this.effectedRegionCommunities = effectedRegionCommunities;


### PR DESCRIPTION
Ticket: https://jag.gov.bc.ca/jira/browse/EMBCDFA-1288
Note: Got ticket number wrong on commit messages. Not sure if it's worth the effort to change them.

This fix adds 2 days to the "Days Remaining to Apply" on both the application component and the events component such that an event due tomorrow will have "2 Days Remaining to Apply" (today and tomorrow) and an event declared today will have "90 Days Remaining to Apply". Also fixed issue with datetime calculation on API where events due today were not being returned as current events as the time was being factored into the calculation. Changing calculation to use DateTime.Today instead of DateTime.Now should fix this.

Also updated the proxy.dev.conf.json to new URLs so the portal can be run independently of the local API.