### PR TITLE
EMBCDFA-1288: Fix date calculation on API, Portal Changes

### DIFF
--- a/dfa/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
+++ b/dfa/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
@@ -738,8 +738,7 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                 if (lstEvents.List.Where(m => m.statuscode == "1").Count() > 0)
                 {
                     var lstActiveEvents = lstEvents.List.Where(m => m.statuscode == "1").ToList();
-
-                    var deadline90days = lstActiveEvents.Where(m => m.dfa_90daydeadlinenew != null && Convert.ToDateTime(m.dfa_90daydeadlinenew) >= DateTime.Today).Count();
+                    var deadline90days = lstActiveEvents.Where(m => m.dfa_90daydeadlinenew != null && Convert.ToDateTime(m.dfa_90daydeadlinenew).Date >= DateTime.Today.Date).Count();
                     if (deadline90days > 0)
                     {
                         return deadline90days;
@@ -767,9 +766,9 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                     }
                 });
 
-                var nowDate = DateTime.Today;
                 // open events are those active events where the 90 day deadline is now or in the future
-                return lstEvents.List.Where(m => m.dfa_90daydeadlinenew != null && Convert.ToDateTime(m.dfa_90daydeadlinenew) >= nowDate && m.statuscode == "1");
+                IEnumerable<dfa_event> listOfEvents = lstEvents.List.Where(m => m.dfa_90daydeadlinenew != null && Convert.ToDateTime(m.dfa_90daydeadlinenew).Date >= DateTime.Today.Date && m.statuscode == "1");
+                return listOfEvents;
             }
             catch (System.Exception ex)
             {

--- a/dfa/src/API/EMBC.DFA.API/Mappers/Mappings.cs
+++ b/dfa/src/API/EMBC.DFA.API/Mappers/Mappings.cs
@@ -456,7 +456,7 @@ namespace EMBC.DFA.API.Mappers
 
             CreateMap<dfa_event, DisasterEvent>()
                 .ForMember(d => d.ninetyDayDeadline, opts => opts.MapFrom(s => s.dfa_90daydeadlinenew))
-                .ForMember(d => d.remainingDays, opts => opts.MapFrom(s => (Convert.ToDateTime(s.dfa_90daydeadlinenew) - DateTime.Now).Days.ToString()))
+                .ForMember(d => d.remainingDays, opts => opts.MapFrom(s => (Convert.ToDateTime(s.dfa_90daydeadlinenew).Date - DateTime.Now.Date).Days.ToString()))
                 .ForMember(d => d.eventId, opts => opts.MapFrom(s => s.dfa_eventid))
                 .ForMember(d => d.startDate, opts => opts.MapFrom(s => s.dfa_startdate))
                 .ForMember(d => d.endDate, opts => opts.MapFrom(s => s.dfa_enddate))

--- a/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.html
+++ b/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.html
@@ -6,9 +6,9 @@
         matTooltipPosition="above">
         <span class="sub-heading" style="float:right;">Event: {{event}}</span>
         <span class="sub-heading" style="float:right;">Submit application before midnight on: {{ninetyDayDeadline | date: "MM/dd/yyyy"}}</span><br/>
-        <span class="sub-heading" style="color:#941372; float:right;" *ngIf="daysToApply>0">{{ daysToApply }} day(s) remaining to apply</span>
-        <span class="sub-heading" style="color:#941372; float:right;" *ngIf="daysToApply==0">DUE MIDNIGHT TODAY</span>
-        <span class="sub-heading" style="color:#941372; float:right;" *ngIf="daysToApply<0">{{ -1 - daysToApply }} DAY(S) OVERDUE</span><br/>
+        <span class="sub-heading" style="color:#941372; float:right;" *ngIf="daysToApply>1">{{ daysToApply }} day(s) remaining to apply</span>
+        <span class="sub-heading" style="color:#941372; float:right;" *ngIf="daysToApply==1">DUE MIDNIGHT TODAY</span>
+        <span class="sub-heading" style="color:#941372; float:right;" *ngIf="daysToApply<1">{{ -1 - daysToApply }} DAY(S) OVERDUE</span><br/>
     </div>
   </div>
   <div class="row heading-container">

--- a/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.ts
@@ -287,7 +287,6 @@ export class DFAApplicationMainComponent
           const dateDifferenceInMs = eventDate.getTime() - currentDateOnly.getTime();
           const differenceInDays = Math.floor(dateDifferenceInMs / (1000 * 60 * 60 * 24));
           this.daysToApply = differenceInDays + 1;
-          console.log("days to apply: ", this.daysToApply);
         }
       })
   }

--- a/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.ts
@@ -282,7 +282,12 @@ export class DFAApplicationMainComponent
           this.ninetyDayDeadline = value;
           let date = new Date(value);
           let currentDate = new Date();
-          this.daysToApply = Math.floor((date.getTime() - currentDate.getTime()) / 1000 / 60 / 60 / 24) + 2; // Account for start and end dates
+          const eventDate = new Date(date.toDateString());
+          const currentDateOnly = new Date(currentDate.toDateString());
+          const dateDifferenceInMs = eventDate.getTime() - currentDateOnly.getTime();
+          const differenceInDays = Math.floor(dateDifferenceInMs / (1000 * 60 * 60 * 24));
+          this.daysToApply = differenceInDays + 1;
+          console.log("days to apply: ", this.daysToApply);
         }
       })
   }

--- a/dfa/src/UI/embc-dfa/src/app/sharedModules/dashboard-components/dfa-events/dfa-events.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/sharedModules/dashboard-components/dfa-events/dfa-events.component.ts
@@ -37,7 +37,7 @@ export class DfaEventsComponent implements OnInit {
   }
 
   getRemainingDays(event: DisasterEvent): string {
-    const remainingDays = Number(event.remainingDays) + 2; // Account for start and end dates
+    const remainingDays = Number(event.remainingDays) + 1; // Account for today
     if (remainingDays === 1) {
       return "Apply by midnight tonight";
     }

--- a/dfa/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-prescreening-forms/prescreening/prescreening.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-prescreening-forms/prescreening/prescreening.component.ts
@@ -345,11 +345,15 @@ export default class PrescreeningComponent implements OnInit, OnDestroy {
 
     // check for date of damage between start date and end date
     this.openDisasterEvents.forEach(disasterEvent => {
-      if (new Date(new Date(disasterEvent.endDate).toDateString()) >= this.prescreeningForm.controls.damageFromDate.value &&
-        new Date(new Date(disasterEvent.startDate).toDateString()) <= this.prescreeningForm.controls.damageFromDate.value) {
+      const damageFromDate = new Date(this.prescreeningForm.controls.damageFromDate.value);
+      const eventStartDate = new Date(new Date(disasterEvent.startDate).toDateString());
+      const eventEndDate = new Date(new Date(disasterEvent.endDate).toDateString());
+      if (eventEndDate >= damageFromDate && eventStartDate <= damageFromDate) {
         disasterEvent.matchDate = true;
-      } else disasterEvent.matchDate = false;
-    })
+      } else {
+        disasterEvent.matchDate = false;
+      }
+    });
 
     // Matching Events to display
     this.matchingEventsData = this.openDisasterEvents.filter(disasterEvent => disasterEvent.matchArea == true && disasterEvent.matchDate == true);


### PR DESCRIPTION
There was an issue on the API side when calculating which events were current events, as it was comparing across the time of the event as well which created issues when the times were mismatched. Changed API code to only check the actual date of the event and not the time. Adjusted front end days remaining calculations to better reflect this change.