### PR TITLE
EMBCDFA-1242: Disable deletion of occupants after submit

### DIFF
--- a/dfa/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-application-main-forms/occupants/occupants.component.html
+++ b/dfa/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-application-main-forms/occupants/occupants.component.html
@@ -49,7 +49,7 @@
                   <td *matCellDef="let element; let index = index" mat-cell>
                     <button
                     class="delete-image"
-                    *ngIf="vieworedit !== 'viewOnly' && vieworedit !== 'view'"
+                    *ngIf="vieworedit !== 'viewOnly' && vieworedit !== 'view' && vieworedit !== 'edit'"
                     mat-icon-button
                     aria-label="Remove"
                     (click)="deleteFullTimeOccupantRow(index)"
@@ -261,7 +261,7 @@
                   <td *matCellDef="let element; let index = index" mat-cell>
                     <button
                     class="delete-image"
-                    *ngIf="vieworedit !== 'viewOnly' && vieworedit !== 'view'"
+                    *ngIf="vieworedit !== 'viewOnly' && vieworedit !== 'view' && vieworedit !== 'edit'"
                     mat-icon-button
                     aria-label="Remove"
                     (click)="deleteSecondaryApplicantRow(index)"
@@ -541,7 +541,7 @@
                     </button>&nbsp;
                     <button
                     class="delete-image"
-                    *ngIf="vieworedit !== 'viewOnly' || contactonly === 'contactOnly'"
+                    *ngIf="(vieworedit !== 'viewOnly' && vieworedit !== 'edit') || contactonly === 'contactOnly'"
                     mat-icon-button
                     aria-label="Remove"
                     (click)="confirmDeleteOtherContactRow(index)"


### PR DESCRIPTION
This ticket contains code to disable the ability to delete occupants that have been added to an application after it has been submitted.

Ticket: https://jag.gov.bc.ca/jira/browse/EMBCDFA-1242?filter=-1

Screenshots below.

Creating an application: Able to delete occupants
![CREATE](https://github.com/user-attachments/assets/6a50a26f-42b0-459c-8e19-04a1e12345a6)

Saving an unsubmitted application, then coming back to edit it: Able to delete occupants
![CONTINUE](https://github.com/user-attachments/assets/d0388879-087c-41a7-916c-54023df26ba0)

After submitting: Unable to delete occupants
![deleteprimaryoccupant](https://github.com/user-attachments/assets/b0d4a296-dc99-401d-9629-890ad7f3dfaa)
