### PR TITLE
Implement new routes for Public Portal on `dev` and `test`

### DIFF
--- a/landing-page/src/html/index.html
+++ b/landing-page/src/html/index.html
@@ -734,7 +734,7 @@ a:hover {
 </style>
 <script type="text/javascript">
 	var privatePortal = 'https://portal.dev.dfa.gov.bc.ca'
-	var publicPortal = 'https://dfa-public-sector-dev.apps.silver.devops.gov.bc.ca'
+	var publicPortal = 'https://publicsector-dev.dfa.gov.bc.ca'
 
 	var apiPrivateUrl = privatePortal + '/api/eligibility/checkEventsAvailable';
 	var eventButtonPrivateUrl = privatePortal + '/verified-registration';

--- a/landing-page/src/html/index.test.html
+++ b/landing-page/src/html/index.test.html
@@ -734,7 +734,7 @@ a:hover {
 </style>
 <script type="text/javascript">
 	var privatePortal = 'https://portal.test.dfa.gov.bc.ca'
-	var publicPortal = 'https://dfa-public-sector-test.apps.silver.devops.gov.bc.ca'
+	var publicPortal = 'https://publicsector-test.dfa.gov.bc.ca'
 
 	var apiPrivateUrl = privatePortal + '/api/eligibility/checkEventsAvailable';
 	var eventButtonPrivateUrl = privatePortal + '/verified-registration';


### PR DESCRIPTION
This PR implements the new routes that were originally set up during the SSL certificate renewal in early October 2024. Helm charts will be modified after the fact.