### PR TITLE
[EMCRI-922] Created extra endpoints to check Dyn contacts table - which are unused for now.

### DIFF
--- a/dfa-public/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
+++ b/dfa-public/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using System.Web;
 using System.Xml;
 using EMBC.DFA.API.ConfigurationModule.Models.AuthModels;
+using EMBC.DFA.API.ConfigurationModule.Models.PDF;
 using EMBC.ESS.Shared.Contracts.Metadata;
 using Google.Protobuf.WellKnownTypes;
 using Grpc.Core;
@@ -1424,6 +1425,29 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
             }
         }
 
+        public async Task<dyn_contact> GetVerifiedPrimaryContactbyBCeIDAsync(string bceidUserId)
+        {
+            try
+            {
+                var userObj = await api.GetList<dyn_contact>("contacts", new CRMGetListOptions
+                {
+                    Select = new[]
+                    {
+                        "contactid",
+                        "dfa_bceid_user_guid",
+                        "fullname",
+                    },
+                    Filter = $"dfa_bceid_user_guid eq '{bceidUserId}'"
+                });
+
+                return userObj != null ? userObj.List.LastOrDefault() : null;
+            }
+            catch (System.Exception ex)
+            {
+                throw new Exception($"Failed to obtain access token from {ex.Message}", ex);
+            }
+        }
+
         public async Task<string> UpsertPrimaryContactAsync(dfa_applicationprimarycontact_params contact)
         {
             try
@@ -1473,7 +1497,7 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                 var result = await api.ExecuteAction("dfa_DFAPortalCreateBCeIDUsers", auditEvent);
                 Debug.WriteLine(result);
 
-                return "foo";
+                return auditEvent.dfa_name;
             }
             catch (System.Exception ex)
             {

--- a/dfa-public/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/Entities.cs
+++ b/dfa-public/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/Entities.cs
@@ -54,6 +54,13 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
         public int? dfa_mailingaddresscanadapostverified { get; set; }
     }
 
+    public class dyn_contact
+    {
+        public string? contactid { get; set; }
+        public string? dfa_bceid_user_guid { get; set; }
+        public string? fullname { get; set; }
+    }
+
     public class dfa_appcontact_extended : dfa_appcontact
     {
         public string? dfa_title { get; set; }
@@ -212,6 +219,8 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
         public int? dfa_mailingaddresscanadapostverified { get; set; }
         public bool? dfa_primarycontactverified { get; set; }
         public int? dfa_toreceivesupportaccessingdamage { get; set; }
+        // 2024-10-29 EMCRI-922 waynezen
+        public string? verified_contact_id { get; set; }
     }
 
     // 2024-09-17 EMCRI-663 waynezen

--- a/dfa-public/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/Handler.cs
+++ b/dfa-public/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/Handler.cs
@@ -70,6 +70,7 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
         Task<dfa_applicationprimarycontact_retrieve> HandleGetPrimaryContactAsync(string contactId);
         Task<dfa_applicationprimarycontact_retrieve> HandleGetPrimaryContactByBCeIDAsync(string bceidUserId);
         Task<string> HandleBCeIDAudit(dfa_audit_event auditEvent);
+        Task<dyn_contact> HandleGetVerifiedPrimaryContactAsync(string bceidUserId);
     }
 
     public class Handler : IConfigurationHandler
@@ -380,6 +381,12 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
         public async Task<string> HandleBCeIDAudit(dfa_audit_event auditEvent)
         {
             var result = await listsGateway.CreateBCeIDAuditEvent(auditEvent);
+            return result;
+        }
+
+        public async Task<dyn_contact> HandleGetVerifiedPrimaryContactAsync(string bceidUserId)
+        {
+            var result = await listsGateway.GetVerifiedPrimaryContactbyBCeIDAsync(bceidUserId);
             return result;
         }
     }

--- a/dfa-public/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/IDynamicsGateway.cs
+++ b/dfa-public/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/IDynamicsGateway.cs
@@ -59,5 +59,7 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
         public Task<dfa_applicationprimarycontact_retrieve> GetPrimaryContactbyContactIdAsync(string contactId);
         public Task<string> UpsertPrimaryContactAsync(dfa_applicationprimarycontact_params contact);
         public Task<string> CreateBCeIDAuditEvent(dfa_audit_event auditEvent);
+
+        public Task<dyn_contact> GetVerifiedPrimaryContactbyBCeIDAsync(string bceidUserId);
     }
 }

--- a/dfa-public/src/API/EMBC.DFA.API/Controllers/ApplicationController.cs
+++ b/dfa-public/src/API/EMBC.DFA.API/Controllers/ApplicationController.cs
@@ -164,6 +164,10 @@ namespace EMBC.DFA.API.Controllers
                 mappedApplication.dfa_bceidbusinessguid = primeContactIn.dfa_bceidbusinessguid;
             }
 
+            // 2024-10-29 EMCRI-922 waynezen; check if a verified Primary Contact exists
+            // 2024-10-30 users will have to manually create a Confirmed Primary Contact in RAFT due to technical limitations
+            mappedApplication.verified_contact_id = null;
+
             var result = await handler.HandleApplicationUpdate(mappedApplication, null);
 
             if (string.IsNullOrEmpty(mappedApplication.dfa_appapplicationid) && result != null && Guid.TryParse(result, out Guid appId))

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-application-main-forms/contacts/contacts.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-application-main-forms/contacts/contacts.component.ts
@@ -505,12 +505,20 @@ export default class ContactsComponent implements OnInit, OnDestroy {
           // 2024-10-11 EMCRI-809 waynezen; get cell phone and job title with data from Dynamics
           this.applicationService.applicationGetPrimaryContactByBCeId({ bceiduserguid: bceidBusiness.userGuid }).subscribe({
             next: (contact) => {
-              this.contactsForm.get('pcCellPhone').setValue(contact.pcCellPhone);
-              this.contactsForm.get('pcJobTitle').setValue(contact.pcJobTitle);
-              // 2024-10-23 EMCRI-901 waynezen; get contact notes, too!
-              this.contactsForm.get('pcNotes').setValue(contact.pcNotes);
+              // 2024-10-29 EMCRI-922 waynezen; if Primary Contact not found, API returns null
+              if (contact) {
+                this.contactsForm.get('pcCellPhone').setValue(contact.pcCellPhone);
+                this.contactsForm.get('pcJobTitle').setValue(contact.pcJobTitle);
+                // 2024-10-23 EMCRI-901 waynezen; get contact notes, too!
+                this.contactsForm.get('pcNotes').setValue(contact.pcNotes);
+              }
+              else {
+                this.contactsForm.get('pcCellPhone').setValue('');
+                this.contactsForm.get('pcJobTitle').setValue('');
+                this.contactsForm.get('pcNotes').setValue('');            
+              }
             }
-            });    
+          });    
 
           this.showFoundContactMsg = true;
           this.dfaApplicationMainDataService.primaryContactValidatedEvent.emit(true);


### PR DESCRIPTION
On Contact screen, if search for Primary Contact finds a user via the BCeID Web service - but doesn't find the user pre-existing in the Dynamics dfa_appapplicant table - three fields are not updated: cell phone, job title and notes.