### PR TITLE
Fix landing page environment banner colour

### DIFF
--- a/landing-page/src/html/index.training.html
+++ b/landing-page/src/html/index.training.html
@@ -650,7 +650,7 @@ a:hover {
 		justify-content: space-between;
 		text-align: center;
 		color: white;
-		background-color: #fc6621;
+		background-color: #630091;
 		p {
 			margin-top: 10px;
 		}


### PR DESCRIPTION
The colour used at present in the landing page environment banner's background is #fc6621, when it should be #630091. This has since been corrected in `index.training.html`.