### PR TITLE
EMCRI# 841 Portal: On Project Dashboard, don't display value in EMCR Approved Amount until project BPF has reached Decision Made

### DIFF
--- a/dfa-public/src/API/EMBC.ESS.Shared.Contracts/EMBC.ESS.Shared.Contracts.csproj
+++ b/dfa-public/src/API/EMBC.ESS.Shared.Contracts/EMBC.ESS.Shared.Contracts.csproj
@@ -31,6 +31,6 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Text.Json" Version="8.0.4" />
+        <PackageReference Include="System.Text.Json" Version="9.0.0" />
     </ItemGroup>
 </Project>

--- a/dfa-public/src/API/EMBC.Utilities.Hosting/EMBC.Utilities.Hosting.csproj
+++ b/dfa-public/src/API/EMBC.Utilities.Hosting/EMBC.Utilities.Hosting.csproj
@@ -41,7 +41,7 @@
         <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.8.1" />
         <PackageReference Include="OpenTelemetry.Instrumentation.StackExchangeRedis" Version="1.0.0-rc9.5" />
         <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
-        <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="1.2.0" />
+        <PackageReference Include="Serilog.Enrichers.ClientInfo" Version="2.1.2" />
         <PackageReference Include="Serilog.Enrichers.CorrelationId" Version="3.0.1" />
         <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
         <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />

--- a/dfa-public/src/API/EMBC.Utilities.Hosting/Logging.cs
+++ b/dfa-public/src/API/EMBC.Utilities.Hosting/Logging.cs
@@ -31,7 +31,7 @@ namespace EMBC.Utilities.Hosting
                 .Enrich.WithEnvironmentUserName()
                 .Enrich.WithCorrelationId()
                 .Enrich.WithCorrelationIdHeader()
-                .Enrich.WithClientAgent()
+                //.Enrich.WithClientAgent()
                 .Enrich.WithClientIp()
                 .Enrich.WithSpan()
                 .WriteTo.Console(outputTemplate: LogOutputTemplate)

--- a/dfa-public/src/API/EMBC.Utilities/EMBC.Utilities.csproj
+++ b/dfa-public/src/API/EMBC.Utilities/EMBC.Utilities.csproj
@@ -38,7 +38,7 @@
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
-        <PackageReference Include="System.Text.Json" Version="8.0.4" />
+        <PackageReference Include="System.Text.Json" Version="9.0.0" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.html
@@ -150,23 +150,24 @@
           </span>
         </div>
       </div>
+      
+      @if(applItem.stage == 'Approved' || applItem.stage == 'Approved with Exclusions') {
       <div style="padding-top: 16px; display: flex;" [hidden]="applItem.isHidden">
-  
-        <div class="col-md-2">
-          <span><b>Site Location - </b></span>
-        </div>
-        <div class="col-md-3 wrap-text">
-          <span>{{applItem.siteLocation }}</span>
-        </div>
-        <div class="col-md-2">
-          <span><b>Estimated Completion Date - </b></span>
-        </div>
-        <div class="col-md-2">
-          <span>{{ applItem.estimatedCompletionDate }}</span>
-        </div>
-        
+          <div class="col-md-2">
+            <span><b>Site Location - </b></span>
+          </div>
+          <div class="col-md-3 wrap-text">
+            <span>{{applItem.siteLocation }}</span>
+          </div>
+          <div class="col-md-2">
+            <span><b>Estimated Completion Date - </b></span>
+          </div>
+          <div class="col-md-2">
+            <span>{{ applItem.estimatedCompletionDate }}</span>
+          </div>
       </div>
       <div style="border-bottom: 1px solid lightgrey; padding-bottom: 16px; display: flex;" [hidden]="applItem.isHidden">
+        
         <div class="col-md-2">
           <span><b>EMCR Approved Amount -</b></span>
         </div>
@@ -180,6 +181,7 @@
           <span id="spnCauseOfDamage">{{ applItem.deadline18Month }}</span>
         </div>
       </div>
+    }
       <div style="width: 90%; min-width: 725px; display: flex; flex-direction: column;">
         <div class="col-md-3" style="margin-top: 20px;">
           <span *ngIf="applItem.isErrorInStatus == true" style="color: red;">Error in displaying status<br /></span>

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.ts
@@ -87,6 +87,7 @@ export class DfaDashProjectComponent implements OnInit {
           var initialList = lstData;
           lstDataUnModified.push(initialList);
           lstData.forEach(objApp => {
+            objApp.isHidden = false;
             var isFound = false;
             var jsonVal = JSON.stringify(this.items);
             objApp.isErrorInStatus = false;


### PR DESCRIPTION
EMCRI# 841 Portal: On Project Dashboard, don't display value in EMCR Approved Amount until project BPF has reached Decision Made
- Fixd the nuget package issues
- Added logic on project dashboard to show the fields only if the decision is approved or Approved with Exclusions