### PR TITLE
EMCRI# 842 Portal: On Claim Dashboard, don't display certain values until claim BPF has reached Decision Made

### DIFF
--- a/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.html
@@ -14,7 +14,7 @@
     <div class="col-8">
       <span class="page-heading">{{ dfaApplicationMainHeading }}</span>
     </div>
-    <br />
+    
     <div class="col-4" *ngIf="vieworedit === 'add' || vieworedit === 'update'" >
       <button
         class="button-p save-button col-4"

--- a/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-claim-main/dfa-claim-main.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-claim-main/dfa-claim-main.component.html
@@ -4,7 +4,7 @@
     <div class="col-8">
       <span class="page-heading">{{ dfaClaimMainHeading }}</span>
     </div>
-    <br />
+   
     <div class="col-4" >
       <button
         #backtodash

--- a/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-main/dfa-project-main.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-main/dfa-project-main.component.html
@@ -4,7 +4,7 @@
     <div class="col-8">
       <span class="page-heading">{{ dfaProjectMainHeading }}</span>
     </div>
-    <br />
+   
     <div class="col-4" *ngIf="vieworedit === 'addproject' || vieworedit === 'updateproject'" >
       <button
         #backtodash

--- a/dfa-public/src/UI/embc-dfa/src/app/models/decision.enum.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/models/decision.enum.ts
@@ -1,0 +1,6 @@
+export enum Decision {
+    Approved = 'Approved',
+    ApprovedwithExclusions = 'Approved with Exclusions',
+    Ineligible = 'Ineligible',
+    Withdrawn = 'Withdrawn',
+}

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/claim-dashboard-components/claim/claim.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/claim-dashboard-components/claim/claim.component.html
@@ -132,18 +132,21 @@
         <div class="col-md-2">
           <span>{{applItem.firstClaim == true ? 'Yes' : (applItem.firstClaim == false ? 'No' : 'Not Set')}}</span>
         </div>
-        <div class="col-md-2">
-          <span><b>Approved Claim Total - </b></span>
-        </div>
-        <div class="col-md-2">
-          <span>{{applItem.approvedClaimTotal}}</span>
-        </div>
-        <div class="col-md-2">
-          <span><b>Eligible Payable - </b></span>
-        </div>
-        <div class="col-md-2">
-          <span>{{applItem.eligiblePayable}}</span>
-        </div>
+        @if(applItem.stage == DecisionEnum.Approved || applItem.stage == DecisionEnum.ApprovedWithExclusions){
+          <div class="col-md-2">
+            <span><b>Approved Claim Total - </b></span>
+          </div>
+          <div class="col-md-2">
+            <span>{{applItem.approvedClaimTotal}}</span>
+          </div>
+          <div class="col-md-2">
+            <span><b>Eligible Payable - </b></span>
+          </div>
+          <div class="col-md-2">
+            <span>{{applItem.eligiblePayable}}</span>
+          </div>
+        }
+        
         
       </div>
       <div style="padding-bottom: 16px; display: flex;" [hidden]="applItem.isHidden">
@@ -153,6 +156,7 @@
         <div class="col-md-2">
           <span id="spnCauseOfDamage">{{applItem.finalClaim == true ? 'Yes' : (applItem.finalClaim == false ? 'No' : 'Not Set')}}</span>
         </div>
+        @if(applItem.stage == DecisionEnum.Approved || applItem.stage == DecisionEnum.ApprovedWithExclusions){
         <div class="col-md-2">
           <span><b>Less First $1,000 -</b></span>
         </div>
@@ -165,7 +169,9 @@
         <div class="col-md-2">
           <span id="spnCauseOfDamage">{{applItem.paidClaimAmount}}</span>
         </div>
+      }
       </div>
+    
 
       <div style="border-bottom: 1px solid lightgrey; padding-bottom: 16px; display: flex;" [hidden]="applItem.isHidden">
         <div class="col-md-2">
@@ -174,6 +180,7 @@
         <div class="col-md-2">
           <span id="spnCauseOfDamage">{{applItem.claimTotal }}</span>
         </div>
+        @if(applItem.stage == DecisionEnum.Approved || applItem.stage == DecisionEnum.ApprovedWithExclusions){
         <div class="col-md-2">
           <span><b>Approved Reimbursement % -</b></span>
         </div>
@@ -186,6 +193,7 @@
         <div class="col-md-2">
           <span id="spnCauseOfDamage">{{applItem.paidClaimDate}}</span>
         </div>
+      }
       </div>
 
       <div style="width: 90%; min-width: 725px; display: flex; flex-direction: column;">

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/claim-dashboard-components/claim/claim.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/claim-dashboard-components/claim/claim.component.ts
@@ -11,6 +11,7 @@ import { CurrentApplication, CurrentClaim, CurrentProject } from 'src/app/core/a
 import { DFAProjectMainDataService } from '../../../feature-components/dfa-project-main/dfa-project-main-data.service';
 import { DFAClaimMainDataService } from '../../../feature-components/dfa-claim-main/dfa-claim-main-data.service';
 import { ClaimService } from '../../../core/api/services';
+import { Decision } from 'src/app/models/decision.enum';
 
 @Component({
   selector: 'app-dfadashboard-claim',
@@ -19,6 +20,8 @@ import { ClaimService } from '../../../core/api/services';
 })
 
 export class DfaDashClaimComponent implements OnInit {
+
+  DecisionEnum = Decision;
 
   addNewItem(value: number) {
     this.appSessionService.currentProjectsCount.emit(value);

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.html
@@ -151,7 +151,7 @@
         </div>
       </div>
       
-      @if(applItem.stage == 'Approved' || applItem.stage == 'Approved with Exclusions') {
+      @if(applItem.stage == DecisionEnum.Approved || applItem.stage == DecisionEnum.ApprovedWithExclusions) {
       <div style="padding-top: 16px; display: flex;" [hidden]="applItem.isHidden">
           <div class="col-md-2">
             <span><b>Site Location - </b></span>

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.ts
@@ -10,6 +10,7 @@ import { DFAApplicationStartDataService } from 'src/app/feature-components/dfa-a
 import { CurrentApplication, CurrentProject } from 'src/app/core/api/models';
 import { DFAProjectMainDataService } from '../../../feature-components/dfa-project-main/dfa-project-main-data.service';
 import { DFAClaimMainDataService } from '../../../feature-components/dfa-claim-main/dfa-claim-main-data.service';
+import { Decision } from 'src/app/models/decision.enum';
 
 @Component({
   selector: 'app-dfadashboard-project',
@@ -18,6 +19,8 @@ import { DFAClaimMainDataService } from '../../../feature-components/dfa-claim-m
 })
 
 export class DfaDashProjectComponent implements OnInit {
+
+  DecisionEnum = Decision;
 
   addNewItem(value: number) {
     this.appSessionService.currentProjectsCount.emit(value);
@@ -86,8 +89,7 @@ export class DfaDashProjectComponent implements OnInit {
           var lstDataUnModified = [];
           var initialList = lstData;
           lstDataUnModified.push(initialList);
-          lstData.forEach(objApp => {
-            objApp.isHidden = false;
+          lstData.forEach(objApp => {       
             var isFound = false;
             var jsonVal = JSON.stringify(this.items);
             objApp.isErrorInStatus = false;


### PR DESCRIPTION
EMCRI# 842 Portal: On Claim Dashboard, don't display certain values until claim BPF has reached Decision Made
- Fixed the styling issue with the title and return to dashboard button on application, project and claim pages
- Fixed the issue with showing certain feilds until claim BPF has reached Decision Made.
- Added decisions enum to add the decision logic on the project and claims dashboard