### PR TITLE
EMCRI-1014 Hide values not relevant to withdrawn or ineligible amendments

### DIFF
--- a/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-amendment/dfa-project-amendment.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-amendment/dfa-project-amendment.component.html
@@ -1,297 +1,319 @@
 <div class="container container-frame">
   <form [formGroup]="projectAmendmentForm">
-  <div class="container">
-    <div class="heading-container">
-      <div class="row">
-        <div class="col-md-6 headerText">
+    <div class="container">
+      <div class="heading-container">
+        <div class="row">
+          <div class="col-md-6 headerText">
           <span class="page-heading">
-            {{projectName}}
-            </span> 
-        </div>
-        <div class="col-md-3 amendment-refresh">
-          <span title="Sync Amendment Details" class="material-symbols-outlined sync-btn" (click)="SyncAmendmentDetails()">
+            {{ projectName }}
+            </span>
+          </div>
+          <div class="col-md-3 amendment-refresh">
+          <span title="Sync Amendment Details" class="material-symbols-outlined sync-btn"
+                (click)="SyncAmendmentDetails()">
           sync
           </span>
-        </div>
-        <div class="col-md-3 headerText ">
-          <mat-form-field appearance="outline">
-           <mat-label>Select Project Amendment</mat-label>
-           <mat-select formControlName="amendmentId" matInput placeholder="Project Amendment" >
-             <mat-option (click)="selectAmendment(option)" *ngFor="let option of ProjectAmendments"
-               [value]="option.amendmentId">
-               {{ option.amendmentNumber }}
-             </mat-option>
-           </mat-select>
-         </mat-form-field>
-           
+          </div>
+          <div class="col-md-3 headerText ">
+            <mat-form-field appearance="outline">
+              <mat-label>Select Project Amendment</mat-label>
+              <mat-select formControlName="amendmentId" matInput placeholder="Project Amendment">
+                <mat-option (click)="selectAmendment(option)" *ngFor="let option of ProjectAmendments"
+                            [value]="option.amendmentId">
+                  {{ option.amendmentNumber }}
+                </mat-option>
+              </mat-select>
+            </mat-form-field>
+
+          </div>
         </div>
       </div>
-    </div>
-    <div class="col-12" >
-      <div class="amendmentTracker">
-        <div class="col-md-3" style="margin: 20px;" *ngIf="isErrorInStatus == true" >
-          <span style="color: red;">Error in displaying status<br /></span>
-        </div>
-        <table cellpadding="0" cellspacing="0">
-          <tr>
-            <td colspan="3" *ngFor="let item of getItems(statusBar); let i=index" id="item{{i}}" [ngClass]="'headerlabelStyle'">
-              <span *ngIf="item.status != ''" class="stepText">{{item.status}}</span>
-            </td>
+      <div class="col-12">
+        <div class="amendmentTracker">
+          <div class="col-md-3" style="margin: 20px;" *ngIf="isErrorInStatus == true">
+            <span style="color: red;">Error in displaying status<br/></span>
+          </div>
+          <table cellpadding="0" cellspacing="0">
+            <tr>
+              <td colspan="3" *ngFor="let item of getItems(statusBar); let i=index" id="item{{i}}"
+                  [ngClass]="'headerlabelStyle'">
+                <span *ngIf="item.status != ''" class="stepText">{{ item.status }}</span>
+              </td>
 
-          </tr>
-          <tr>
-            <td *ngFor="let item of statusBar; let i=index" id="item{{i}}" [ngClass]="item.status != '' ? 'labelStyle' : 'labelEmptyWidth'">
-              <!--<div *ngIf="item.status != '' && item.currentStep == false" [ngClass]=" i == 0 ? 'removeBorder' : 'lineConnector'"></div>-->
-              <div *ngIf="item.status != ''" [ngClass]="item.currentStep == false || item.status == 'Closed' ? 'alignStatus': (item.stage == '' ? 'alignStatus' : 'currentStatus')">
-                <span *ngIf="status != 'Closed' && item.isCompleted == true && isErrorInStatus == false" class="material-icons" [ngStyle]="{'color': item.stage == 'Ineligible' || item.stage == 'Withdrawn' ? 'red' : 'rgb(21 178 89)'}">
+            </tr>
+            <tr>
+              <td *ngFor="let item of statusBar; let i=index" id="item{{i}}"
+                  [ngClass]="item.status != '' ? 'labelStyle' : 'labelEmptyWidth'">
+                <!--<div *ngIf="item.status != '' && item.currentStep == false" [ngClass]=" i == 0 ? 'removeBorder' : 'lineConnector'"></div>-->
+                <div *ngIf="item.status != ''"
+                     [ngClass]="item.currentStep == false || item.status == 'Closed' ? 'alignStatus': (item.stage == '' ? 'alignStatus' : 'currentStatus')">
+                <span *ngIf="status != 'Closed' && item.isCompleted == true && isErrorInStatus == false"
+                      class="material-icons"
+                      [ngStyle]="{'color': item.stage == 'Ineligible' || item.stage == 'Withdrawn' ? 'red' : 'rgb(21 178 89)'}">
                   {{ item.stage == 'Ineligible' || item.stage == 'Withdrawn' ? 'cancel' : 'check_circle' }}
                 </span>
-                <span *ngIf="status == 'Closed' && item.isCompleted == true && isErrorInStatus == false" class="material-icons" [ngStyle]="{'color': item.status == 'Decision Made' && (stage == 'Ineligible' || stage == 'Withdrawn') ? 'red' : 'rgb(21 178 89)'}">
-                  {{ item.status == 'Decision Made' && (stage == 'Ineligible' || stage == 'Withdrawn')  ? 'cancel' : 'check_circle' }}
+                  <span *ngIf="status == 'Closed' && item.isCompleted == true && isErrorInStatus == false"
+                        class="material-icons"
+                        [ngStyle]="{'color': item.status == 'Decision Made' && (stage == 'Ineligible' || stage == 'Withdrawn') ? 'red' : 'rgb(21 178 89)'}">
+                  {{ item.status == 'Decision Made' && (stage == 'Ineligible' || stage == 'Withdrawn') ? 'cancel' : 'check_circle' }}
                 </span>
-                <span *ngIf="item.isCompleted == false && item.currentStep == true && isErrorInStatus == false && item.stage != ''">
-                  {{item.stage}}
+                  <span
+                    *ngIf="item.isCompleted == false && item.currentStep == true && isErrorInStatus == false && item.stage != ''">
+                  {{ item.stage }}
                 </span>
-                <span *ngIf="item.isCompleted == false && item.currentStep == true && isErrorInStatus == false && item.stage == ''" class="material-symbols-outlined" [ngStyle]="{'color': item.status == 'Draft' ? '#639DD4' : '#FDCB52'}">
+                  <span
+                    *ngIf="item.isCompleted == false && item.currentStep == true && isErrorInStatus == false && item.stage == ''"
+                    class="material-symbols-outlined"
+                    [ngStyle]="{'color': item.status == 'Draft' ? '#639DD4' : '#FDCB52'}">
                   {{ item.status == 'Draft' ? 'check_circle' : 'circle' }}
                 </span>
-                <span *ngIf="item.isCompleted == false && item.currentStep == false && isErrorInStatus == false" class="material-symbols-outlined" style="color: #FDCB52">
+                  <span *ngIf="item.isCompleted == false && item.currentStep == false && isErrorInStatus == false"
+                        class="material-symbols-outlined" style="color: #FDCB52">
                   circle
                 </span>
-                <span *ngIf="isErrorInStatus == true" class="material-symbols-outlined" style="color: #FDCB52">
+                  <span *ngIf="isErrorInStatus == true" class="material-symbols-outlined" style="color: #FDCB52">
                   circle
                 </span>
-              </div>
-              <!--<div *ngIf="item.status != '' && item.currentStep == false && (i+1) < statusBar.length" class="lineConnector"></div>-->
-              <div class="lineConnector" *ngIf="item.status == '' && i > 1 && (i+1) < statusBar.length"></div>
-            </td>
-          </tr>
-        </table>
+                </div>
+                <!--<div *ngIf="item.status != '' && item.currentStep == false && (i+1) < statusBar.length" class="lineConnector"></div>-->
+                <div class="lineConnector" *ngIf="item.status == '' && i > 1 && (i+1) < statusBar.length"></div>
+              </td>
+            </tr>
+          </table>
 
-      </div>
-    </div>
-    <div class="col-12 content-container appDetailHeader" >
-      <div class="row">
-        <div class="col-md-6"><b>Case Number - </b>{{caseNumber}} </div>
-        <div class="col-md-6"><b>Date of Damage (From) - </b>{{dateOfDamageFrom | date : 'MM/dd/yyyy'}}</div>
-      </div>
-      <div class="row">
-        <div class="col-md-6 wrap-text"><b>Cause of Damage - </b>{{causeOfDamage}}</div>
-        <div class="col-md-6"><b>Date of Damage (To) - </b>{{dateOfDamageTo | date : 'MM/dd/yyyy'}}</div>
-      </div>
-    </div>
-    <br />
-    <mat-card class="card-align recoveryPlan" style="border:none;" [class.mat-elevation-z0]="true">
-      <mat-card-content>
-        <div class="container" style="padding-bottom: 100px; padding-top: 30px;">
-        <app-alert></app-alert>
-        <div class="row">
-          <div class="col-md-3">
-            <p  style="font-size: 15px; margin-bottom: 10px !important">
-              Amendment Number
-            </p>
-            <mat-form-field appearance="outline" class="mat-form-round">
-              <input
-                formControlName="amendmentNumber"
-                matInput
-                />
-            </mat-form-field>
-          </div>
-          <div class="col-md-3">
-            <p  style="font-size: 15px">
-              Amendment Received Date
-            </p>
-            <mat-form-field appearance="outline" class="mat-form-round">
-              <input matInput
-                formControlName="amendmentReceivedDate"
-              
-                >
-              <mat-hint>MM/DD/YYYY</mat-hint>
-              <mat-datepicker-toggle matSuffix [for]="amendmentReceivedDatePicker" disabled
-              ></mat-datepicker-toggle>
-              <mat-datepicker #amendmentReceivedDatePicker disabled
-              ></mat-datepicker>
-            </mat-form-field>
-          </div>
         </div>
-
+      </div>
+      <div class="col-12 content-container appDetailHeader">
         <div class="row">
-          <div class="col-md-12">
-            <p  style="font-size: 15px; margin-bottom: 10px !important">
-              Amendment Reason
-            </p>
-            <mat-form-field appearance="outline" class="mat-form-round text-area-width">
+          <div class="col-md-6"><b>Case Number - </b>{{ caseNumber }}</div>
+          <div class="col-md-6"><b>Date of Damage (From) - </b>{{ dateOfDamageFrom | date : 'MM/dd/yyyy' }}</div>
+        </div>
+        <div class="row">
+          <div class="col-md-6 wrap-text"><b>Cause of Damage - </b>{{ causeOfDamage }}</div>
+          <div class="col-md-6"><b>Date of Damage (To) - </b>{{ dateOfDamageTo | date : 'MM/dd/yyyy' }}</div>
+        </div>
+      </div>
+      <br/>
+      <div *ngFor="let option of ProjectAmendments">
+      <mat-card class="card-align recoveryPlan" style="border:none;" [class.mat-elevation-z0]="true">
+        <mat-card-content>
+          <div class="container" style="padding-bottom: 100px; padding-top: 30px;">
+            <app-alert></app-alert>
+            <div class="row">
+              <div class="col-md-3">
+                <p style="font-size: 15px; margin-bottom: 10px !important">
+                  Amendment Number
+                </p>
+                <mat-form-field appearance="outline" class="mat-form-round">
+                  <input
+                    formControlName="amendmentNumber"
+                    matInput
+                  />
+                </mat-form-field>
+              </div>
+              <div class="col-md-3">
+                <p style="font-size: 15px">
+                  Amendment Received Date
+                </p>
+                <mat-form-field appearance="outline" class="mat-form-round">
+                  <input matInput
+                         formControlName="amendmentReceivedDate"
+
+                  >
+                  <mat-hint>MM/DD/YYYY</mat-hint>
+                  <mat-datepicker-toggle matSuffix [for]="amendmentReceivedDatePicker" disabled
+                  ></mat-datepicker-toggle>
+                  <mat-datepicker #amendmentReceivedDatePicker disabled
+                  ></mat-datepicker>
+                </mat-form-field>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="col-md-12">
+                <p style="font-size: 15px; margin-bottom: 10px !important">
+                  Amendment Reason
+                </p>
+                <mat-form-field appearance="outline" class="mat-form-round text-area-width">
               <textarea matInput
-                formControlName="amendmentReason"
-                style="resize:none"
-                cdkTextareaAutosize
-                #autosize="cdkTextareaAutosize"
-                cdkAutosizeMinRows="3"
-                cdkAutosizeMaxRows="5"></textarea>
-            </mat-form-field>
-          </div>
-        </div>
-
-        <div class="row">
-          <div class="col-md-3">
-            <p  style="font-size: 15px">
-              Amendment Approved Date
-            </p>
-            <mat-form-field appearance="outline">
-              <input matInput
-                formControlName="amendmentApprovedDate"
-                >
-              <mat-hint>MM/DD/YYYY</mat-hint>
-              <mat-datepicker-toggle matSuffix [for]="amendmentApprovedDatePicker" disabled
-              ></mat-datepicker-toggle>
-              <mat-datepicker #amendmentApprovedDatePicker disabled
-              ></mat-datepicker>
-            </mat-form-field>
-          </div>
-        </div>
-        <br />
-        <div class="row">
-          <div class="col-md-12">
-            <p  style="font-size: 15px; margin-bottom: 10px !important">
-              EMCR Decision Comments
-            </p>
-            <mat-form-field appearance="outline" class="mat-form-round text-area-width">
+                        formControlName="amendmentReason"
+                        style="resize:none"
+                        cdkTextareaAutosize
+                        #autosize="cdkTextareaAutosize"
+                        cdkAutosizeMinRows="3"
+                        cdkAutosizeMaxRows="5"></textarea>
+                </mat-form-field>
+              </div>
+            </div>
+            @if (option.stage == DecisionEnum.Approved || option.stage == DecisionEnum.ApprovedWithExclusions) {
+              <div class="row">
+                <div class="col-md-3">
+                  <p style="font-size: 15px">
+                    Amendment Approved Date
+                  </p>
+                  <mat-form-field appearance="outline">
+                    <input matInput
+                           formControlName="amendmentApprovedDate"
+                    >
+                    <mat-hint>MM/DD/YYYY</mat-hint>
+                    <mat-datepicker-toggle matSuffix [for]="amendmentApprovedDatePicker" disabled
+                    ></mat-datepicker-toggle>
+                    <mat-datepicker #amendmentApprovedDatePicker disabled
+                    ></mat-datepicker>
+                  </mat-form-field>
+                </div>
+              </div>
+              <br/>
+              <div class="row">
+                <div class="col-md-12">
+                  <p style="font-size: 15px; margin-bottom: 10px !important">
+                    EMCR Decision Comments
+                  </p>
+                  <mat-form-field appearance="outline" class="mat-form-round text-area-width">
               <textarea matInput
-                formControlName="emcrDecisionComments"
-                style="resize:none"
-                cdkTextareaAutosize
-                #autosize="cdkTextareaAutosize"
-                cdkAutosizeMinRows="3"
-                cdkAutosizeMaxRows="5"></textarea>
-            </mat-form-field>
-          </div>
-        </div>
-        <hr />
-        <div><b>Project Extension</b></div><br />
-        <div class="row">
-          <div class="col-md-3">
-            <p  style="font-size: 15px; margin-bottom: 10px !important">
-              Request for Project Deadline Extention
-            </p>
-            <mat-form-field appearance="outline" class="mat-form-round">
-              <input
-                formControlName="requestforProjectDeadlineExtention"
-                matInput
-                />
-            </mat-form-field>
-          </div>
-          <div class="col-md-3">
-            <p  style="font-size: 15px">
-              Amended Project Deadline Date
-            </p>
-            <mat-form-field appearance="outline">
-              <input matInput
-                formControlName="amendedProjectDeadlineDate"
-                >
-              <mat-hint>MM/DD/YYYY</mat-hint>
-              <mat-datepicker-toggle matSuffix [for]="amendedProjectDeadlineDatePicker" disabled
-              ></mat-datepicker-toggle>
-              <mat-datepicker #amendedProjectDeadlineDatePicker disabled
-              ></mat-datepicker>
-            </mat-form-field>
-          </div>
-          <div class="col-md-3">
-            <p  style="font-size: 15px; margin-bottom: 10px !important">
-              Deadline Extension Approved
-            </p>
-            <mat-form-field appearance="outline" class="mat-form-round">
-              <input
-                formControlName="deadlineExtensionApproved"
-                matInput
-                />
-            </mat-form-field>
-          </div>
-          <div class="col-md-3">
-            <p  style="font-size: 15px">
-              Amended 18 Month Deadline
-            </p>
-            <mat-form-field appearance="outline">
-              <input matInput
-                formControlName="amended18MonthDeadline"
-              
-                >
-              <mat-hint>MM/DD/YYYY</mat-hint>
-              <mat-datepicker-toggle matSuffix [for]="amended18MonthDeadlineDatePicker" disabled
-              ></mat-datepicker-toggle>
-              <mat-datepicker #amended18MonthDeadlineDatePicker disabled
-              ></mat-datepicker>
-            </mat-form-field>
-          </div>
-        </div>
-
-        <hr />
-        <div><b>Additional Costs</b></div><br />
-        <div class="row">
-          <div class="col-md-3">
-            <p  style="font-size: 15px; margin-bottom: 10px !important">
-              Request for Additional Project Cost
-            </p>
-            <mat-form-field appearance="outline" class="mat-form-round">
-              <input
-                formControlName="requestforAdditionalProjectCost"
-                matInput
-                />
-            </mat-form-field>
-          </div>
-          <div class="col-md-3">
-            <p  style="font-size: 15px">
-              Estimated Additional Project Cost
-            </p>
-            <mat-form-field appearance="outline" class="mat-form-round">
-  
-              <div class="searchDiv">
-                <input
-                  #currencyBoxestimatedAdditionalProjectCost
-                  id="currencyBoxestimatedAdditionalProjectCost"
-                  formControlName="estimatedAdditionalProjectCost"
-                  matInput
-                  mask="separator.2" thousandSeparator="" decimalMarker="."
-                  maxlength="100"/>
-                <span class="currencyText">CA$</span>
+                        formControlName="emcrDecisionComments"
+                        style="resize:none"
+                        cdkTextareaAutosize
+                        #autosize="cdkTextareaAutosize"
+                        cdkAutosizeMinRows="3"
+                        cdkAutosizeMaxRows="5"></textarea>
+                  </mat-form-field>
+                </div>
               </div>
-  
-            </mat-form-field>
-          </div>
-          <div class="col-md-3">
-            <p  style="font-size: 15px; margin-bottom: 10px !important">
-              Additional Project Cost Decision
-            </p>
-            <mat-form-field appearance="outline" class="mat-form-round">
-              <input
-                formControlName="additionalProjectCostDecision"
-                matInput
-                />
-            </mat-form-field>
-          </div>
-          <div class="col-md-3 costCurrency">
-            <p  style="font-size: 15px">
-              Approved Additional Project Cost
-            </p>
-            <mat-form-field appearance="outline" class="mat-form-round">
-  
-              <div class="searchDiv">
-                <input
-                  #currencyBoxapprovedAdditionalProjectCost
-                  id="currencyBoxapprovedAdditionalProjectCost"
-                  formControlName="approvedAdditionalProjectCost"
-                  matInput
-                  mask="separator.2" thousandSeparator="" decimalMarker="."
-                  maxlength="100"/>
-                <span class="currencyText">CA$</span>
+            }
+            <hr/>
+            <div><b>Project Extension</b></div>
+            <br/>
+            <div class="row">
+              <div class="col-md-3">
+                <p style="font-size: 15px; margin-bottom: 10px !important">
+                  Request for Project Deadline Extention
+                </p>
+                <mat-form-field appearance="outline" class="mat-form-round">
+                  <input
+                    formControlName="requestforProjectDeadlineExtention"
+                    matInput
+                  />
+                </mat-form-field>
               </div>
-  
-            </mat-form-field>
-          </div>
-        </div>
+              <div class="col-md-3">
+                <p style="font-size: 15px">
+                  Amended Project Deadline Date
+                </p>
+                <mat-form-field appearance="outline">
+                  <input matInput
+                         formControlName="amendedProjectDeadlineDate"
+                  >
+                  <mat-hint>MM/DD/YYYY</mat-hint>
+                  <mat-datepicker-toggle matSuffix [for]="amendedProjectDeadlineDatePicker" disabled
+                  ></mat-datepicker-toggle>
+                  <mat-datepicker #amendedProjectDeadlineDatePicker disabled
+                  ></mat-datepicker>
+                </mat-form-field>
+              </div>
+              @if (option.stage == DecisionEnum.Approved || option.stage == DecisionEnum.ApprovedWithExclusions) {
+                <div class="col-md-3">
+                  <p style="font-size: 15px; margin-bottom: 10px !important">
+                    Deadline Extension Approved
+                  </p>
+                  <mat-form-field appearance="outline" class="mat-form-round">
+                    <input
+                      formControlName="deadlineExtensionApproved"
+                      matInput
+                    />
+                  </mat-form-field>
+                </div>
+                <div class="col-md-3">
+                  <p style="font-size: 15px">
+                    Amended 18 Month Deadline
+                  </p>
+                  <mat-form-field appearance="outline">
+                    <input matInput
+                           formControlName="amended18MonthDeadline"
 
+                    >
+                    <mat-hint>MM/DD/YYYY</mat-hint>
+                    <mat-datepicker-toggle matSuffix [for]="amended18MonthDeadlineDatePicker" disabled
+                    ></mat-datepicker-toggle>
+                    <mat-datepicker #amended18MonthDeadlineDatePicker disabled
+                    ></mat-datepicker>
+                  </mat-form-field>
+                </div>
+              }
+            </div>
+
+            <hr/>
+            <div><b>Additional Costs</b></div>
+            <br/>
+            <div class="row">
+              <div class="col-md-3">
+                <p style="font-size: 15px; margin-bottom: 10px !important">
+                  Request for Additional Project Cost
+                </p>
+                <mat-form-field appearance="outline" class="mat-form-round">
+                  <input
+                    formControlName="requestforAdditionalProjectCost"
+                    matInput
+                  />
+                </mat-form-field>
+              </div>
+              <div class="col-md-3">
+                <p style="font-size: 15px">
+                  Estimated Additional Project Cost
+                </p>
+                <mat-form-field appearance="outline" class="mat-form-round">
+
+                  <div class="searchDiv">
+                    <input
+                      #currencyBoxestimatedAdditionalProjectCost
+                      id="currencyBoxestimatedAdditionalProjectCost"
+                      formControlName="estimatedAdditionalProjectCost"
+                      matInput
+                      mask="separator.2" thousandSeparator="" decimalMarker="."
+                      maxlength="100"/>
+                    <span class="currencyText">CA$</span>
+                  </div>
+
+                </mat-form-field>
+              </div>
+              @if (option.stage == DecisionEnum.Approved || option.stage == DecisionEnum.ApprovedWithExclusions) {
+                <div class="col-md-3">
+                  <p style="font-size: 15px; margin-bottom: 10px !important">
+                    Additional Project Cost Decision
+                  </p>
+                  <mat-form-field appearance="outline" class="mat-form-round">
+                    <input
+                      formControlName="additionalProjectCostDecision"
+                      matInput
+                    />
+                  </mat-form-field>
+                </div>
+                <div class="col-md-3 costCurrency">
+                  <p style="font-size: 15px">
+                    Approved Additional Project Cost
+                  </p>
+                  <mat-form-field appearance="outline" class="mat-form-round">
+
+                    <div class="searchDiv">
+                      <input
+                        #currencyBoxapprovedAdditionalProjectCost
+                        id="currencyBoxapprovedAdditionalProjectCost"
+                        formControlName="approvedAdditionalProjectCost"
+                        matInput
+                        mask="separator.2" thousandSeparator="" decimalMarker="."
+                        maxlength="100"/>
+                      <span class="currencyText">CA$</span>
+                    </div>
+
+                  </mat-form-field>
+                </div>
+              }
+            </div>
+
+          </div>
+        </mat-card-content>
+      </mat-card>
       </div>
-      </mat-card-content>
-    </mat-card>
     </div>
-</form>
+  </form>
 </div>

--- a/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-amendment/dfa-project-amendment.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-amendment/dfa-project-amendment.component.ts
@@ -45,6 +45,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { DFAProjectMainMappingService } from '../dfa-project-main/dfa-project-main-mapping.service';
 import { ProjectAmendment } from '../../core/model/dfa-project-main.model';
 import { DFAGeneralInfoDialogComponent } from '../../core/components/dialog-components/dfa-general-info-dialog/dfa-general-info-dialog.component';
+import { Decision } from 'src/app/models/decision.enum';
 
 
 @Component({
@@ -93,6 +94,7 @@ export class DFAProjectAmendmentComponent
   statusBar?: null | Array<ProjectStatusBar>;
   isErrorInStatus?: null | boolean;
   projectName = '';
+  DecisionEnum = Decision;
 
   constructor(
     //@Inject('formBuilder') formBuilder: UntypedFormBuilder,
@@ -115,21 +117,21 @@ export class DFAProjectAmendmentComponent
   }
 
   ngOnInit(): void {
-    
+
 
     this.projectAmendmentForm$ = this.formCreationService
       .getProjectAmendmentForm()
       .subscribe((projectAmendment) => {
         this.projectAmendmentForm = projectAmendment;
       });
-    
+
     this.appId = this.dfaProjectMainDataService.getApplicationId(); //this.route.snapshot.paramMap.get('id');
     this.projectId = this.dfaProjectMainDataService.getProjectId();
     this.applicationNumber = 'Application';
     this.getApplicationDetials(this.appId);
     this.getRecoveryPlan(this.projectId);
     this.getAmendmentDetials(this.projectId);
-    
+
     this.dfaProjectMainDataService.setApplicationId(this.appId);
     this.disableFormfields();
   }
@@ -149,7 +151,7 @@ export class DFAProjectAmendmentComponent
     this.projectAmendmentForm.controls.additionalProjectCostDecision.disable();
     this.projectAmendmentForm.controls.approvedAdditionalProjectCost.disable();
   }
-  
+
   getApplicationDetials(applicationId: string) {
     if (applicationId) {
       this.applicationService.applicationGetApplicationDetailsForProject({ applicationId: applicationId }).subscribe({
@@ -243,7 +245,7 @@ export class DFAProjectAmendmentComponent
           if (dfaAmendment) {
             var amendmentId = this.projectAmendmentForm.controls.amendmentId.value;
             this.ProjectAmendments = dfaAmendment;
-            
+
             if (dfaAmendment && dfaAmendment.length > 0) {
               var selectedAmendment = dfaAmendment.filter(m => m.amendmentId == amendmentId);
               if (selectedAmendment.length > 0) {
@@ -256,13 +258,13 @@ export class DFAProjectAmendmentComponent
             else {
               let noAmendment = 'No amendment found for the project!<br/>Click \'Close\' button to go back to Project Dashboard';
               this.ConfirmAndGoBack(noAmendment);
-              
+
             }
           }
           else {
             let noAmendment = 'No amendment found for the project!<br/>Click \'Close\' button to go back to Project Dashboard';
             this.ConfirmAndGoBack(noAmendment);
-            
+
           }
 
         },
@@ -357,7 +359,7 @@ export class DFAProjectAmendmentComponent
     else {
       this.isErrorInStatus = true;
     }
-      
+
 
     //this.mapData(lstDataModified);
 
@@ -374,7 +376,7 @@ export class DFAProjectAmendmentComponent
   }
 
   ngAfterViewInit(): void {
-    
+
   }
 
 }

--- a/dfa-public/src/UI/embc-dfa/src/app/models/decision.enum.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/models/decision.enum.ts
@@ -1,6 +1,6 @@
 export enum Decision {
     Approved = 'Approved',
-    ApprovedwithExclusions = 'Approved with Exclusions',
+    ApprovedWithExclusions = 'Approved with Exclusions',
     Ineligible = 'Ineligible',
     Withdrawn = 'Withdrawn',
 }


### PR DESCRIPTION
Added some logic to the amendment display from to remove fields if the amendment was withdrawn or ineligible.

Approved:

<img width="1128" alt="image" src="https://github.com/user-attachments/assets/62aee4c5-b200-4948-ac7b-0a1de7371315" />

ineligible or withdrawn:

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/f224bf9a-c2d0-4a4f-9b22-c9200daad553" />
