### PR TITLE
EMCRI # 843 Portal: On submitted Claim, don't display certain values until claim BPF has reached Decision Made

### DIFF
--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
@@ -1250,7 +1250,7 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                         "dfa_finalclaim", "createdon", "dfa_claimreceivedbyemcrdate",
                         "dfa_totaleligiblegst", "dfa_totaloftotaleligible", "dfa_totalapproved", "dfa_lessfirst1000",
                         "dfa_costsharing", "dfa_eligiblepayable", "dfa_totalpaid", "dfa_claimpaiddate",
-                        "dfa_claimtotal", "dfa_paidclaimamount", "dfa_onetimedeductionamount"
+                        "dfa_claimtotal", "dfa_paidclaimamount", "dfa_onetimedeductionamount", "dfa_claimbpfstages", "dfa_claimbpfsubstages"
                     },
                     Filter = $"dfa_projectclaimid eq {claimId}"
                 });
@@ -1274,6 +1274,9 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                                    dfa_totalpaid = objApp.dfa_totalpaid,
                                    dfa_claimtotal = objApp.dfa_claimtotal,
                                    dfa_paidclaimamount = objApp.dfa_paidclaimamount,
+                                   dfa_claimbpfstages = objApp.dfa_claimbpfstages,
+                                   dfa_claimbpfsubstages = objApp.dfa_claimbpfsubstages
+
                                }).AsEnumerable().OrderByDescending(m => m.createdon);
 
                 return lstApps.FirstOrDefault();

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/Entities.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/Entities.cs
@@ -305,6 +305,9 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
         public string? dfa_claimtotal { get; set; }
         public string? dfa_paidclaimamount { get; set; }
         public string? dfa_onetimedeductionamount { get; set; }
+        public string? dfa_claimbpfstages { get; set; }
+        public string? dfa_claimbpfsubstages { get; set; }
+
     }
 
     public class dfa_appapplicationmain_retrieve

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/SharedModels.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/SharedModels.cs
@@ -591,6 +591,8 @@ namespace EMBC.DFA.API.Controllers
         public string? paidClaimDate { get; set; }
         public string? claimReceivedByEMCRDate { get; set; }
         public Invoice[]? invoices { get; set; }
+        public string stage { get; set; }
+        public string status { get; set; }
     }
 
     public class Invoice

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Mappers/Mappings.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Mappers/Mappings.cs
@@ -561,8 +561,11 @@ namespace EMBC.DFA.API.Mappers
                 .ForMember(d => d.paidClaimAmount, opts => opts.MapFrom(s => string.IsNullOrEmpty(s.dfa_paidclaimamount) ? "0" : s.dfa_paidclaimamount))
                 .ForMember(d => d.claimReceivedByEMCRDate, opts => opts.MapFrom(s => Convert.ToDateTime(s.dfa_claimreceivedbyemcrdate).Year < 2020 ? "Date Not Set" : Convert.ToDateTime(s.dfa_claimreceivedbyemcrdate).ToString("MM/dd/yyyy", CultureInfo.InvariantCulture)))
                 .ForMember(d => d.paidClaimDate, opts => opts.MapFrom(s => Convert.ToDateTime(s.dfa_claimpaiddate).Year < 2020 ? "Date Not Set" : Convert.ToDateTime(s.dfa_claimpaiddate).ToString("MM/dd/yyyy", CultureInfo.InvariantCulture)))
-
-                ;
+                .ForMember(d => d.status, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_claimbpfstages) ? GetEnumDescription((ClaimStages)Convert.ToInt32(s.dfa_claimbpfstages)) : null))
+                .ForMember(d => d.stage, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_claimbpfsubstages) ?
+                    (Convert.ToInt32(s.dfa_claimbpfstages) == Convert.ToInt32(ClaimStages.Draft) ? null : GetEnumDescription((ClaimSubStages)Convert.ToInt32(s.dfa_claimbpfsubstages)))
+                    : null));
+                
 
             CreateMap<dfa_appapplication, CurrentApplication>()
                 .ForMember(d => d.DateOfDamage, opts => opts.MapFrom(s => s.dfa_dateofdamage))

--- a/dfa-public/src/UI/embc-dfa/src/app/core/api/models/recovery-claim.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/api/models/recovery-claim.ts
@@ -19,6 +19,8 @@ export interface RecoveryClaim {
   isThisFinalClaim?: null | boolean;
   paidClaimAmount?: null | string;
   paidClaimDate?: null | string;
+  stage?: string;
+  status?: string;
   totalActualClaim?: null | string;
   totalInvoicesBeingClaimed?: null | string;
 }

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/recovery-claim/recovery-claim.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/recovery-claim/recovery-claim.component.html
@@ -197,6 +197,7 @@
       </ng-container>
       <br />
 
+    @if(recoveryClaim.claim.stage == DecisionEnum.Approved || recoveryClaim.claim.stage == DecisionEnum.ApprovedwithExclusions){
       <ng-container *ngIf="isReadOnly == true">
         <div class="row decisionHeader">
           <b>Decision</b>
@@ -365,6 +366,7 @@
           </div>
         </div>
       </ng-container>
+    }
     </form>
     
   </mat-card-content>

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/recovery-claim/recovery-claim.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/recovery-claim/recovery-claim.component.ts
@@ -24,7 +24,7 @@ import { MatRadioModule } from '@angular/material/radio';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatInputModule } from '@angular/material/input';
 import { DFAApplicationMainDataService } from 'src/app/feature-components/dfa-application-main/dfa-application-main-data.service';
-import { ApplicantOption, ApplicantSubtypeSubCategories } from 'src/app/core/api/models';
+import { ApplicantOption, ApplicantSubtypeSubCategories, DfaClaimMain } from 'src/app/core/api/models';
 import { MatTableModule } from '@angular/material/table';
 import { CustomPipeModule } from 'src/app/core/pipe/customPipe.module';
 import { DFADeleteConfirmDialogComponent } from '../../../../core/components/dialog-components/dfa-confirm-delete-dialog/dfa-confirm-delete.component';
@@ -42,6 +42,7 @@ import { MAT_TOOLTIP_DEFAULT_OPTIONS, MatTooltipDefaultOptions } from '@angular/
 import { DFAClaimMainDataService } from '../../../../feature-components/dfa-claim-main/dfa-claim-main-data.service';
 import { DFAClaimMainMappingService } from '../../../../feature-components/dfa-claim-main/dfa-claim-main-mapping.service';
 import { ActivatedRoute } from '@angular/router';
+import { Decision } from 'src/app/models/decision.enum';
 
 export const myCustomTooltipDefaults: MatTooltipDefaultOptions = {
   showDelay: 0,
@@ -58,6 +59,9 @@ export const myCustomTooltipDefaults: MatTooltipDefaultOptions = {
   providers: [{ provide: MAT_TOOLTIP_DEFAULT_OPTIONS, useValue: myCustomTooltipDefaults }]
 })
 export default class RecoveryClaimComponent implements OnInit, OnDestroy {
+
+  DecisionEnum = Decision;
+  
   //@ViewChild('projectName') projectName: ElementRef;
   message : string = '';
   recoveryClaimForm: UntypedFormGroup;
@@ -85,6 +89,8 @@ export default class RecoveryClaimComponent implements OnInit, OnDestroy {
     /\d/,
     /\d/
   ];
+
+  recoveryClaim?: DfaClaimMain;
 
   constructor(
     @Inject('formBuilder') formBuilder: UntypedFormBuilder,
@@ -237,10 +243,13 @@ export default class RecoveryClaimComponent implements OnInit, OnDestroy {
     }
   }
 
+
+
   getRecoveryClaim(claimId: string) {
     if (claimId) {
       this.claimService.claimGetClaimMain({ claimId: claimId }).subscribe({
         next: (dfaClaimMain) => {
+          this.recoveryClaim = dfaClaimMain;
           this.dfaClaimMainMapping.mapDFAClaimMain(dfaClaimMain);
           
         },


### PR DESCRIPTION
EMCRI # 843 Portal: On submitted Claim, don't display certain values until claim BPF has reached Decision Made
- Added stage and substage fields in the dynamics gate way
- Added stage and status fields to the entity
- Updated the recovery claims mappings
- Updated the logic to show the decisions only if they are in approved states