### PR TITLE
EMCRI# 842 EMCRI# 843 Portal: On submitted Claim, don't display certain values until claim BPF has reached Decision Made

### DIFF
--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
@@ -1075,7 +1075,8 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                             "dfa_amendmentreceiveddate",
                             "dfa_amendmentstages",
                             "dfa_amendmentsubstages",
-                            "dfa_projectamendmentid"
+                            "dfa_projectamendmentid",
+                            "dfa_amendmentdecision"
                         },
                     Filter = $"_dfa_project_value eq {projectId}"
                     //Filter = $"_dfa_project_value eq 25fff2cb-a15b-4c94-bd94-c9107e8b383a"
@@ -1102,6 +1103,7 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                                    dfa_amended18monthdeadline = !string.IsNullOrEmpty(objApp.dfa_amended18monthdeadline) ? DateTime.Parse(objApp.dfa_amended18monthdeadline).ToLocalTime().ToString() : objApp.dfa_amended18monthdeadline,
                                    dfa_amendmentapproveddate = !string.IsNullOrEmpty(objApp.dfa_amendmentapproveddate) ? DateTime.Parse(objApp.dfa_amendmentapproveddate).ToLocalTime().ToString() : objApp.dfa_amendmentapproveddate,
                                    dfa_amendmentreceiveddate = !string.IsNullOrEmpty(objApp.dfa_amendmentreceiveddate) ? DateTime.Parse(objApp.dfa_amendmentreceiveddate).ToLocalTime().ToString() : objApp.dfa_amendmentreceiveddate,
+                                   dfa_amendmentdecision = objApp.dfa_amendmentdecision,
                                }).AsEnumerable().OrderByDescending(m => m.createdon);
 
                 return lstPrjAmnds;

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
@@ -1174,7 +1174,7 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                         "dfa_claimbpfstages", "dfa_claimbpfsubstages", "dfa_claimtotal",
                         "createdon", "dfa_costsharing", "dfa_eligiblepayable",
                         "dfa_bpfclosedate", "dfa_onetimedeductionamount",
-                        "dfa_paidclaimamount"
+                        "dfa_paidclaimamount",  "dfa_decisioncopy"
                     },
                     Filter = $"_dfa_recoveryplanid_value eq {projectId}"
                 });
@@ -1203,6 +1203,7 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                                    dfa_bpfclosedate = !string.IsNullOrEmpty(objClaim.dfa_bpfclosedate) ? DateTime.Parse(objClaim.dfa_bpfclosedate).ToLocalTime().ToString() : objClaim.dfa_bpfclosedate,
                                    dfa_onetimedeductionamount = objClaim.dfa_onetimedeductionamount,
                                    dfa_paidclaimamount = objClaim.dfa_paidclaimamount,
+                                   dfa_decisioncopy = objClaim.dfa_decisioncopy
                                }).AsEnumerable().OrderByDescending(m => m.createdon);
 
                 return lstClaims;
@@ -1253,7 +1254,7 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                         "dfa_finalclaim", "createdon", "dfa_claimreceivedbyemcrdate",
                         "dfa_totaleligiblegst", "dfa_totaloftotaleligible", "dfa_totalapproved", "dfa_lessfirst1000",
                         "dfa_costsharing", "dfa_eligiblepayable", "dfa_totalpaid", "dfa_claimpaiddate",
-                        "dfa_claimtotal", "dfa_paidclaimamount", "dfa_onetimedeductionamount", "dfa_claimbpfstages", "dfa_claimbpfsubstages"
+                        "dfa_claimtotal", "dfa_paidclaimamount", "dfa_onetimedeductionamount", "dfa_claimbpfstages", "dfa_claimbpfsubstages", "dfa_decisioncopy"
                     },
                     Filter = $"dfa_projectclaimid eq {claimId}"
                 });
@@ -1278,7 +1279,8 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
                                    dfa_claimtotal = objApp.dfa_claimtotal,
                                    dfa_paidclaimamount = objApp.dfa_paidclaimamount,
                                    dfa_claimbpfstages = objApp.dfa_claimbpfstages,
-                                   dfa_claimbpfsubstages = objApp.dfa_claimbpfsubstages
+                                   dfa_claimbpfsubstages = objApp.dfa_claimbpfsubstages,
+                                   dfa_decisioncopy = objApp.dfa_decisioncopy
 
                                }).AsEnumerable().OrderByDescending(m => m.createdon);
 

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/Entities.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/Entities.cs
@@ -932,6 +932,8 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
         public string? dfa_amendmentstages { get; set; }
         public string? dfa_amendmentsubstages { get; set; }
         public DateTime createdon { get; set; }
+
+        public string? dfa_amendmentdecision { get; set; }
     }
 
     public enum EventType
@@ -1091,6 +1093,21 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
 
         [Description("Approved with Exclusions")]
         ApprovedwithExclusions = 222710007,
+    }
+
+    public enum ProjectAmendmentDecsions
+    {
+        [Description("Approved")]
+        Approved = 222710000,
+
+        [Description("Ineligible")]
+        Ineligible = 222710001,
+
+        [Description("Withdrawn")]
+        Withdrawn = 222710002,
+
+        [Description("Approved with Exclusions")]
+        ApprovedwithExclusions = 222710003,
     }
 
     public enum ProjectAmendmentAdditionalProjectCostDecision

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/Entities.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/Entities.cs
@@ -308,6 +308,8 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
         public string? dfa_claimbpfstages { get; set; }
         public string? dfa_claimbpfsubstages { get; set; }
 
+        public string? dfa_decisioncopy { get; set; }
+
     }
 
     public class dfa_appapplicationmain_retrieve
@@ -867,6 +869,8 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
         public string? dfa_bpfclosedate { get; set; }
         public string? dfa_onetimedeductionamount { get; set; }
         public string? dfa_paidclaimamount { get; set; }
+
+        public string?  dfa_decisioncopy { get; set; }
     }
 
     public class dfa_recoveryinvoice
@@ -1176,6 +1180,20 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
         ApprovedwithExclusion = 222710008,
     }
 
+    public enum ClaimDecisions
+    {
+        [Description("Approved")]
+        Approved = 222710000,
+
+        [Description("Ineligible")]
+        Ineligible = 222710001,
+
+        [Description("Withdrawn")]
+        Withdrawn = 222710002,
+
+        [Description("Approved with exclusions")]
+        ApprovedwithExclusion = 222710003,
+    }
     public enum EMCRDecision
     {
         [Description("Approved Total")]

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/ClaimController.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/ClaimController.cs
@@ -191,6 +191,8 @@ namespace EMBC.DFA.API.Controllers
         public bool IsHidden { get; set; } = true;
         public string StatusColor { get; set; }
         public string DateFileClosed { get; set; }
+
+        public string ClaimDecision { get; set; }
     }
 
     public class ClaimStatusBar

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/ProjectController.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/ProjectController.cs
@@ -177,6 +177,8 @@ namespace EMBC.DFA.API.Controllers
         public bool IsErrorInStatus { get; set; }
         public bool IsHidden { get; set; } = true;
         public string StatusColor { get; set; }
+
+        public string AmendmentDecision { get; set; }
     }
 
     public class CurrentProject

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/SharedModels.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/SharedModels.cs
@@ -591,8 +591,9 @@ namespace EMBC.DFA.API.Controllers
         public string? paidClaimDate { get; set; }
         public string? claimReceivedByEMCRDate { get; set; }
         public Invoice[]? invoices { get; set; }
-        public string stage { get; set; }
-        public string status { get; set; }
+        public string? stage { get; set; }
+        public string? status { get; set; }
+        public string? claimDecision { get; set; }
     }
 
     public class Invoice

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Mappers/Mappings.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Mappers/Mappings.cs
@@ -547,7 +547,8 @@ namespace EMBC.DFA.API.Mappers
                 .ForMember(d => d.Stage, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_claimbpfsubstages) ?
                     (Convert.ToInt32(s.dfa_claimbpfstages) == Convert.ToInt32(ClaimStages.Draft) ? null : GetEnumDescription((ClaimSubStages)Convert.ToInt32(s.dfa_claimbpfsubstages)))
                     : null))
-                .ForMember(d => d.PaidClaimDate, opts => opts.MapFrom(s => string.IsNullOrEmpty(s.dfa_claimpaiddate) ? "(pending information)" : Convert.ToDateTime(s.dfa_claimpaiddate).ToString("MM/dd/yyyy", CultureInfo.InvariantCulture)));
+                .ForMember(d => d.PaidClaimDate, opts => opts.MapFrom(s => string.IsNullOrEmpty(s.dfa_claimpaiddate) ? "(pending information)" : Convert.ToDateTime(s.dfa_claimpaiddate).ToString("MM/dd/yyyy", CultureInfo.InvariantCulture)))
+                .ForMember(d => d.ClaimDecision, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_decisioncopy) ? GetEnumDescription((ClaimDecisions)Convert.ToInt32(s.dfa_decisioncopy)) : null));
 
             CreateMap<dfa_claim_retrieve, RecoveryClaim>()
                 .ForMember(d => d.claimNumber, opts => opts.MapFrom(s => s.dfa_name))
@@ -566,7 +567,8 @@ namespace EMBC.DFA.API.Mappers
                 .ForMember(d => d.status, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_claimbpfstages) ? GetEnumDescription((ClaimStages)Convert.ToInt32(s.dfa_claimbpfstages)) : null))
                 .ForMember(d => d.stage, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_claimbpfsubstages) ?
                     (Convert.ToInt32(s.dfa_claimbpfstages) == Convert.ToInt32(ClaimStages.Draft) ? null : GetEnumDescription((ClaimSubStages)Convert.ToInt32(s.dfa_claimbpfsubstages)))
-                    : null));
+                    : null))
+                .ForMember(d => d.claimDecision, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_decisioncopy) ? GetEnumDescription((ClaimDecisions)Convert.ToInt32(s.dfa_decisioncopy)) : null));
                 
 
             CreateMap<dfa_appapplication, CurrentApplication>()

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Mappers/Mappings.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Mappers/Mappings.cs
@@ -506,7 +506,8 @@ namespace EMBC.DFA.API.Mappers
                 .ForMember(d => d.RequestforAdditionalProjectCost, opts => opts.MapFrom(s => s.dfa_requestforadditionalprojectcost == true ? "Yes" : "No"))
                 .ForMember(d => d.Status, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_amendmentstages) ? GetEnumDescription((ProjectAmendmentStages)Convert.ToInt32(s.dfa_amendmentstages)) : null))
                 .ForMember(d => d.Stage, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_amendmentsubstages) ? GetEnumDescription((ProjectAmendmentSubStages)Convert.ToInt32(s.dfa_amendmentsubstages)) : null))
-                .ForMember(d => d.AdditionalProjectCostDecision, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_additionalprojectcostdecision) ? GetEnumDescription((ProjectAmendmentAdditionalProjectCostDecision)Convert.ToInt32(s.dfa_additionalprojectcostdecision)) : null));
+                .ForMember(d => d.AdditionalProjectCostDecision, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_additionalprojectcostdecision) ? GetEnumDescription((ProjectAmendmentAdditionalProjectCostDecision)Convert.ToInt32(s.dfa_additionalprojectcostdecision)) : null))
+                .ForMember(d => d.AmendmentDecision, opts => opts.MapFrom(s => !string.IsNullOrEmpty(s.dfa_amendmentdecision) ? GetEnumDescription((ProjectAmendmentDecsions)Convert.ToInt32(s.dfa_amendmentdecision)) : null));
 
             CreateMap<dfa_project, CurrentProject>()
                 .ForMember(d => d.Deadline18Month, opts => opts.MapFrom(s => Convert.ToDateTime(s.dfa_18monthdeadline).Year < 2020 ? "Date Not Set" : Convert.ToDateTime(s.dfa_18monthdeadline).ToString("MM/dd/yyyy", CultureInfo.InvariantCulture)))

--- a/dfa-public/src/UI/embc-dfa/src/app/core/api/models/current-claim.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/api/models/current-claim.ts
@@ -5,6 +5,7 @@ export interface CurrentClaim {
   applicationId?: string;
   approvedClaimTotal?: string;
   approvedReimbursePercent?: string;
+  claimDecision?: string;
   claimId?: string;
   claimNumber?: string;
   claimTotal?: string;

--- a/dfa-public/src/UI/embc-dfa/src/app/core/api/models/current-project-amendment.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/api/models/current-project-amendment.ts
@@ -6,6 +6,7 @@ export interface CurrentProjectAmendment {
   amended18MonthDeadline?: string;
   amendedProjectDeadlineDate?: string;
   amendmentApprovedDate?: string;
+  amendmentDecision?: string;
   amendmentId?: string;
   amendmentNumber?: string;
   amendmentReason?: string;

--- a/dfa-public/src/UI/embc-dfa/src/app/core/api/models/recovery-claim.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/api/models/recovery-claim.ts
@@ -5,6 +5,7 @@ import { Invoice } from './invoice';
 export interface RecoveryClaim {
   approvedClaimTotal?: null | string;
   approvedReimbursement?: null | string;
+  claimDecision?: null | string;
   claimEligibleGST?: null | string;
   claimGrossGST?: null | string;
   claimNumber?: null | string;
@@ -19,8 +20,8 @@ export interface RecoveryClaim {
   isThisFinalClaim?: null | boolean;
   paidClaimAmount?: null | string;
   paidClaimDate?: null | string;
-  stage?: string;
-  status?: string;
+  stage?: null | string;
+  status?: null | string;
   totalActualClaim?: null | string;
   totalInvoicesBeingClaimed?: null | string;
 }

--- a/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-amendment/dfa-project-amendment.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-amendment/dfa-project-amendment.component.html
@@ -145,7 +145,7 @@
                 </mat-form-field>
               </div>
             </div>
-            @if (option.stage == DecisionEnum.Approved || option.stage == DecisionEnum.ApprovedWithExclusions) {
+            @if (option.amendmentDecision == DecisionEnum.Approved || option.stage == amendmentDecision.ApprovedWithExclusions) {
               <div class="row">
                 <div class="col-md-3">
                   <p style="font-size: 15px">
@@ -211,7 +211,7 @@
                   ></mat-datepicker>
                 </mat-form-field>
               </div>
-              @if (option.stage == DecisionEnum.Approved || option.stage == DecisionEnum.ApprovedWithExclusions) {
+              @if (option.amendmentDecision == DecisionEnum.Approved || option.amendmentDecision == DecisionEnum.ApprovedWithExclusions) {
                 <div class="col-md-3">
                   <p style="font-size: 15px; margin-bottom: 10px !important">
                     Deadline Extension Approved
@@ -276,7 +276,7 @@
 
                 </mat-form-field>
               </div>
-              @if (option.stage == DecisionEnum.Approved || option.stage == DecisionEnum.ApprovedWithExclusions) {
+              @if (option.amendmentDecision == DecisionEnum.Approved || option.amendmentDecision == DecisionEnum.ApprovedWithExclusions) {
                 <div class="col-md-3">
                   <p style="font-size: 15px; margin-bottom: 10px !important">
                     Additional Project Cost Decision

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/claim-dashboard-components/claim/claim.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/claim-dashboard-components/claim/claim.component.html
@@ -132,7 +132,7 @@
         <div class="col-md-2">
           <span>{{applItem.firstClaim == true ? 'Yes' : (applItem.firstClaim == false ? 'No' : 'Not Set')}}</span>
         </div>
-        @if(applItem.stage == DecisionEnum.Approved || applItem.stage == DecisionEnum.ApprovedWithExclusions){
+        @if(applItem.claimDecision == DecisionEnum.Approved || applItem.claimDecision == DecisionEnum.ApprovedWithExclusions){
           <div class="col-md-2">
             <span><b>Approved Claim Total - </b></span>
           </div>
@@ -156,7 +156,7 @@
         <div class="col-md-2">
           <span id="spnCauseOfDamage">{{applItem.finalClaim == true ? 'Yes' : (applItem.finalClaim == false ? 'No' : 'Not Set')}}</span>
         </div>
-        @if(applItem.stage == DecisionEnum.Approved || applItem.stage == DecisionEnum.ApprovedWithExclusions){
+        @if(applItem.claimDecision == DecisionEnum.Approved || applItem.claimDecision == DecisionEnum.ApprovedWithExclusions){
         <div class="col-md-2">
           <span><b>Less First $1,000 -</b></span>
         </div>
@@ -180,7 +180,7 @@
         <div class="col-md-2">
           <span id="spnCauseOfDamage">{{applItem.claimTotal }}</span>
         </div>
-        @if(applItem.stage == DecisionEnum.Approved || applItem.stage == DecisionEnum.ApprovedWithExclusions){
+        @if(applItem.claimDecision == DecisionEnum.Approved || applItem.claimDecision == DecisionEnum.ApprovedWithExclusions){
         <div class="col-md-2">
           <span><b>Approved Reimbursement % -</b></span>
         </div>

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/recovery-claim/recovery-claim.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/recovery-claim/recovery-claim.component.html
@@ -197,7 +197,7 @@
       </ng-container>
       <br />
 
-    @if(recoveryClaim.claim.stage == DecisionEnum.Approved || recoveryClaim.claim.stage == DecisionEnum.ApprovedWithExclusions){
+    @if(recoveryClaim.claim.claimDecision == DecisionEnum.Approved || recoveryClaim.claim.claimDecision == DecisionEnum.ApprovedWithExclusions){
       <ng-container *ngIf="isReadOnly == true">
         <div class="row decisionHeader">
           <b>Decision</b>


### PR DESCRIPTION
EMCRI# 842 EMCRI# 843 Portal: On submitted Claim, don't display certain values until claim BPF has reached Decision Made
- Added dfa_decisioncopy field on the current claim and recovery claim endpoints, Dynamics gateway and entities
- Created Enum for the claim Decision 
- Updated mappings for current and recovery claims
- Updated logic on claim dashboard and recovery claims page to get the claim status and show fields based on this