### PR TITLE
EMCRI# 1014 Portal: On Project Amendment form, don't display values in certain fields until project amendment has been approved or approved with exceptions

### DIFF
--- a/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-amendment/dfa-project-amendment.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-amendment/dfa-project-amendment.component.html
@@ -145,7 +145,7 @@
                 </mat-form-field>
               </div>
             </div>
-            @if (option.amendmentDecision == DecisionEnum.Approved || option.stage == amendmentDecision.ApprovedWithExclusions) {
+            @if (option.amendmentDecision == DecisionEnum.Approved || option.amendmentDecision == DecisionEnum.ApprovedWithExclusions) {
               <div class="row">
                 <div class="col-md-3">
                   <p style="font-size: 15px">

--- a/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-amendment/dfa-project-amendment.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/feature-components/dfa-project-amendment/dfa-project-amendment.component.ts
@@ -245,7 +245,6 @@ export class DFAProjectAmendmentComponent
           if (dfaAmendment) {
             var amendmentId = this.projectAmendmentForm.controls.amendmentId.value;
             this.ProjectAmendments = dfaAmendment;
-
             if (dfaAmendment && dfaAmendment.length > 0) {
               var selectedAmendment = dfaAmendment.filter(m => m.amendmentId == amendmentId);
               if (selectedAmendment.length > 0) {
@@ -322,8 +321,8 @@ export class DFAProjectAmendmentComponent
           objStatItem.currentStep = true;
           isFound = true
 
-          if (objAmendment.stage) {
-            objStatItem.stage = objAmendment.stage;
+          if (objAmendment.amendmentDecision) {
+            objStatItem.stage = objAmendment.amendmentDecision;
           }
 
           objAmendment.statusColor = objStatItem.statusColor;


### PR DESCRIPTION
EMCRI# 1014 Portal: On Project Amendment form, don't display values in certain fields until project amendment has been approved or approved with exceptions
- Fixed the issue with the amendment decision not showing on the top bar.
- Fixed the logic for Enums