### PR TITLE
DEVOPS-255: Add conditional to prevent environment banner in production

### DIFF
--- a/dfa/src/UI/embc-dfa/src/app/app.component.html
+++ b/dfa/src/UI/embc-dfa/src/app/app.component.html
@@ -4,7 +4,7 @@
     (closeEvent)="closeOutageBanner($event)"
   ></app-outage-banner>
 
-  <app-environment-banner *ngIf="environment" [environment]="environment"></app-environment-banner>
+  <app-environment-banner *ngIf="environment?.envName !== 'prod'" [environment]="environment"></app-environment-banner>
 
   <app-header
     [ngStyle]="


### PR DESCRIPTION
# Background
EMCR found that the environment banner was loading in DFA's private portal when accessed via `/registration-method`. This is an undesirable behaviour, so a conditional statement was implemented in the `app.component.html` file template to stop it from loading when the `prod` envName is configured in OpenShift.

## Related Ticket & Context
[DEVOPS-255](https://emcr.atlassian.net/browse/DEVOPS-255)

## Affected files
* `dfa/src/UI/embc-dfa/src/app/app.component.html`