### PR TITLE
DEVOPS-357: Migrate OpenShift Tekton image promotion pipelines to GitHub Actions

### DIFF
--- a/.github/workflows/cd-dfa-private-portal-api-prod.yaml
+++ b/.github/workflows/cd-dfa-private-portal-api-prod.yaml
@@ -1,0 +1,39 @@
+name: cd-dfa-private-portal-api-prod
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-api
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: training
+  IMAGE_PROMOTE_ENV_TAG: prod
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: prod-backup
+
+jobs:
+  backup-dfa-private-portal-api:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Promote existing prod dfa-portal-api image to prod-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+
+      - name: Promote dfa-portal-api to prod
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}

--- a/.github/workflows/cd-dfa-private-portal-api-test.yaml
+++ b/.github/workflows/cd-dfa-private-portal-api-test.yaml
@@ -1,0 +1,39 @@
+name: cd-dfa-private-portal-api-test
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-api
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: dev
+  IMAGE_PROMOTE_ENV_TAG: test
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: test-backup
+
+jobs:
+  backup-dfa-private-portal-api:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Promote existing test dfa-portal-api image to test-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+
+      - name: Promote dfa-portal-api to test
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}

--- a/.github/workflows/cd-dfa-private-portal-api-training.yaml
+++ b/.github/workflows/cd-dfa-private-portal-api-training.yaml
@@ -1,0 +1,39 @@
+name: cd-dfa-private-portal-api-training
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-api
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: test
+  IMAGE_PROMOTE_ENV_TAG: training
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: training-backup
+
+jobs:
+  backup-dfa-private-portal-api:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Promote existing training dfa-portal-api image to training-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+
+      - name: Promote dfa-portal-api to training
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}

--- a/.github/workflows/cd-dfa-private-portal-ui-prod.yaml
+++ b/.github/workflows/cd-dfa-private-portal-ui-prod.yaml
@@ -1,0 +1,40 @@
+name: cd-dfa-private-portal-ui-prod
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-ui
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: training
+  IMAGE_PROMOTE_ENV_TAG: prod
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: prod-backup
+
+jobs:
+  backup-dfa-private-portal-ui:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retag existing prod dfa-portal-ui image to prod-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+      
+      - name: Promote dfa-portal-ui to prod
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+

--- a/.github/workflows/cd-dfa-private-portal-ui-test.yaml
+++ b/.github/workflows/cd-dfa-private-portal-ui-test.yaml
@@ -1,0 +1,39 @@
+name: cd-dfa-private-portal-ui-test
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-ui
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: dev
+  IMAGE_PROMOTE_ENV_TAG: test
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: test-backup
+
+jobs:
+  backup-dfa-private-portal-ui:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retag existing test dfa-portal-ui image to test-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+      
+      - name: Promote dfa-portal-ui to test
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}

--- a/.github/workflows/cd-dfa-private-portal-ui-training.yaml
+++ b/.github/workflows/cd-dfa-private-portal-ui-training.yaml
@@ -1,0 +1,39 @@
+name: cd-dfa-private-portal-ui-training
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-ui
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: test
+  IMAGE_PROMOTE_ENV_TAG: training
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: training-backup
+
+jobs:
+  backup-dfa-private-portal-ui:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retag existing training dfa-portal-ui image to training-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+      
+      - name: Promote dfa-portal-ui to training
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}

--- a/.github/workflows/cd-dfa-public-portal-api-prod.yaml
+++ b/.github/workflows/cd-dfa-public-portal-api-prod.yaml
@@ -1,0 +1,39 @@
+name: cd-dfa-public-portal-api-prod
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-api-public
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: training
+  IMAGE_PROMOTE_ENV_TAG: prod
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: prod-backup
+
+jobs:
+  dfa-public-portal-api-to-prod:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retag existing prod dfa-portal-api-public image to prod-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+      
+      - name: Promote dfa-portal-api-public to prod
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}      

--- a/.github/workflows/cd-dfa-public-portal-api-test.yaml
+++ b/.github/workflows/cd-dfa-public-portal-api-test.yaml
@@ -1,0 +1,40 @@
+name: cd-dfa-public-portal-api-test
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-api-public
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: dev
+  IMAGE_PROMOTE_ENV_TAG: test
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: test-backup
+
+jobs:
+  dfa-public-portal-api-to-test:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retag existing prod dfa-portal-api-public image to test-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+      
+      - name: Promote dfa-portal-api-public to test
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}      
+

--- a/.github/workflows/cd-dfa-public-portal-api-training.yaml
+++ b/.github/workflows/cd-dfa-public-portal-api-training.yaml
@@ -1,0 +1,39 @@
+name: cd-dfa-public-portal-api-training
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-api-public
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: test
+  IMAGE_PROMOTE_ENV_TAG: training
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: training-backup
+
+jobs:
+  dfa-public-portal-api-to-training:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retag existing prod dfa-portal-api-public image to training-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+      
+      - name: Promote dfa-portal-api-public to training
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}      

--- a/.github/workflows/cd-dfa-public-portal-ui-prod.yaml
+++ b/.github/workflows/cd-dfa-public-portal-ui-prod.yaml
@@ -1,0 +1,39 @@
+name: cd-dfa-public-portal-ui-prod
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-ui-public
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: training
+  IMAGE_PROMOTE_ENV_TAG: prod
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: prod-backup
+
+jobs:
+  backup-dfa-public-portal-ui:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retag existing prod dfa-portal-ui-public image to prod-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+
+      - name: Promote dfa-portal-ui-public to prod
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}

--- a/.github/workflows/cd-dfa-public-portal-ui-test.yaml
+++ b/.github/workflows/cd-dfa-public-portal-ui-test.yaml
@@ -1,0 +1,39 @@
+name: cd-dfa-public-portal-ui-test
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-ui-public
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: dev
+  IMAGE_PROMOTE_ENV_TAG: test
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: test-backup
+
+jobs:
+  backup-dfa-public-portal-ui:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retag existing test dfa-portal-ui-public image to test-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+
+      - name: Promote dfa-portal-ui-public to test
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}

--- a/.github/workflows/cd-dfa-public-portal-ui-training.yaml
+++ b/.github/workflows/cd-dfa-public-portal-ui-training.yaml
@@ -1,0 +1,40 @@
+name: cd-dfa-public-portal-ui-training
+
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: dfa-portal-ui-public
+  IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
+  IMAGE_CURRENT_ENV_TAG: test
+  IMAGE_PROMOTE_ENV_TAG: training
+  IMAGE_PROMOTE_ENV_BACKUP_TAG: training-backup
+
+jobs:
+  backup-dfa-public-portal-ui:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'bcgov'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Retag existing prod dfa-portal-ui-public image to training-backup
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_BACKUP_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+
+      - name: Promote dfa-portal-ui-public to training
+        uses: tinact/docker.image-retag@master
+        with:
+          image_name: ${{ env.IMAGE_NAME }}
+          image_old_tag: ${{ env.IMAGE_CURRENT_ENV_TAG }}
+          image_new_tag: ${{ env.IMAGE_PROMOTE_ENV_TAG }}
+          registry: ${{ env.IMAGE_REGISTRY }}
+          registry_username: ${{ secrets.OCP4_USERNAME }}
+          registry_password: ${{ secrets.OCP4_PASSWORD }}
+


### PR DESCRIPTION
This migration is the first step to managing releases in GitHub Actions rather than OpenShift. At present, these image promotion workflows will only operate on a `workflow_dispatch` event; this will eventually be replaced by a release's `publish` or `released` event trigger.