### PR TITLE
DEVOPS-357: Replace Docker `file` spec with `context`

### DIFF
--- a/.github/workflows/cd-private-portal-api.yaml
+++ b/.github/workflows/cd-private-portal-api.yaml
@@ -1,7 +1,6 @@
 name: Build Private Portal API
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - support-develop
@@ -10,9 +9,11 @@ on:
       - "dfa/src/API/**"
       - ".github/workflows/cd-private-portal-api.yaml"
 
+  workflow_dispatch:
+
 env:
+  DOCKER_CONTEXT_DIRECTORY: ./dfa/src/API
   IMAGE_NAME: dfa-portal-api
-  DFA_PRIVATE_API_DOCKERFILE_PATH: ./dfa/src/API/Dockerfile
   IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
 
 jobs:
@@ -54,7 +55,7 @@ jobs:
             VERSION=${{ env.VERSION }}
           cache-from: |
             ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          file: ${{ env.DFA_PRIVATE_API_DOCKERFILE_PATH }}
+          context: ${{ env.DOCKER_CONTEXT_DIRECTORY }}
           push: true
           tags: |
             ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest

--- a/.github/workflows/cd-private-portal-ui.yaml
+++ b/.github/workflows/cd-private-portal-ui.yaml
@@ -8,10 +8,12 @@ on:
     paths:
       - "dfa/src/UI/**"
       - ".github/workflows/cd-private-portal-ui.yaml"
+  
+  workflow_dispatch:
 
 env:
+  DOCKER_CONTEXT_DIRECTORY: ./dfa/src/UI
   IMAGE_NAME: dfa-portal-ui
-  DFA_PRIVATE_UI_DOCKERFILE_PATH: ./dfa/src/UI/Dockerfile
   IMAGE_REGISTRY: ${{ secrets.OCP4_REGISTRY }}/${{ secrets.OCP4_NAMESPACE }}
 
 jobs:
@@ -53,7 +55,7 @@ jobs:
             VERSION=${{ env.VERSION }}
           cache-from: |
             ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}
-          file: ${{ env.DFA_PRIVATE_UI_DOCKERFILE_PATH }}
+          file: ${{ env.DOCKER_CONTEXT_DIRECTORY }}
           push: true
           tags: |
             ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
In #765, a restructuring of the Private Portal build workflows was done to bring them in line with how other GitHub Actions workflows are built and managed. However, the Dockerfiles responsible for building DFA's Private Portal API and UI were overlooked in how they each respectively go about building their respective services. As a result, the Dockerfile spec that was used in the GitHub Actions workflow was erroneous as the Dockerfiles rely exclusively on the respective working directory being set ahead of time.

This PR changes that spec to use a Docker `context` spec rather than a `file` spec at the `Build and push` stage.