### PR TITLE
DEVOPS-258: Remove push event condition

### DIFF
--- a/.github/workflows/promote-landing-page-prod.yaml
+++ b/.github/workflows/promote-landing-page-prod.yaml
@@ -13,7 +13,6 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Error was accidentally committed where the landing page production promotion workflow contained a `push` event condition where the workflow is purely triggered on `workflow_dispatch`. This has now been rectified.