### PR TITLE
DFA- 64: Environment banner colours added for Dev, Test and Train for Public Sector Openshift

### DIFF
--- a/dfa-public/src/UI/embc-dfa/angular.json
+++ b/dfa-public/src/UI/embc-dfa/angular.json
@@ -26,6 +26,7 @@
               "src/favicon.ico",
               "src/dfa/favicon.ico",
               "src/assets",
+              "src/assets/env",
               "src/dfa",
               "src/dfa/img",
               {

--- a/dfa-public/src/UI/embc-dfa/src/app/app.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/app.component.html
@@ -4,10 +4,7 @@
     (closeEvent)="closeOutageBanner($event)"
   ></app-outage-banner>
 
-  <!--<app-environment-banner
-    [environment]="environment"
-    *ngIf="environment !== null && environment !== undefined"
-  ></app-environment-banner>-->
+  <app-environment-banner *ngIf="environment?.envName !== 'prod'" [environment]="environment"></app-environment-banner>
 
   <app-header
     [ngStyle]="
@@ -60,3 +57,4 @@
   >
   </app-loader>
 </div>
+

--- a/dfa-public/src/UI/embc-dfa/src/app/app.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/app.component.ts
@@ -36,8 +36,7 @@ export class AppComponent implements OnInit {
 
   public async ngOnInit(): Promise<void> {
     try {
-      //this.environment = await this.configService.loadEnvironmentBanner();
-      this.environment = null;
+      this.environment = await this.configService.loadEnvironmentBanner();
       await this.bootstrapService.init();
       // await this.loginService.tryLogin();
     } catch (error) {
@@ -75,3 +74,4 @@ export class AppComponent implements OnInit {
     this.outageService.closeBannerbyUser = !$event;
   }
 }
+

--- a/dfa-public/src/UI/embc-dfa/src/app/core/layout/environment-banner/environment-banner.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/layout/environment-banner/environment-banner.component.html
@@ -1,11 +1,13 @@
 <div
-  class="container main-style"
+  class="w-100 main-style"
   [ngStyle]="{ 'background-color': environment?.bannerColor }"
 >
-  <p>
-    <markdown [data]="environment?.bannerTitle"></markdown>
-  </p>
-  <p>
-    <markdown [data]="environment?.bannerSubTitle"></markdown>
-  </p>
+  <div class="container">
+    <p>
+      <markdown [data]="environment?.bannerTitle"></markdown>
+    </p>
+    <p>
+      <markdown [data]="environment?.bannerSubTitle"></markdown>
+    </p>
+  </div>
 </div>

--- a/dfa-public/src/UI/embc-dfa/src/app/core/services/config.service.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/services/config.service.ts
@@ -21,7 +21,7 @@ import * as globalConst from '../services/globalConstants';
 })
 export class ConfigService {
   public environmentBanner: EnvironmentInformation;
-  private configurationGetEnvironmentInfoPath = '/env/info.json';
+  private configurationGetEnvironmentInfoPath = 'assets/env/info.json';
 
   public get configuration(): Configuration {
     return JSON.parse(this.cacheService.get('configuration'));
@@ -130,8 +130,9 @@ export class ConfigService {
     return environment;
   }
 
-  private getEnvironment(): Observable<EnvironmentInformation> {
-    const envUrl = this.configurationGetEnvironmentInfoPath;
-    return this.http.get(envUrl);
+  public getEnvironment(): Observable<EnvironmentInformation> {
+    const envUrl = this.configurationGetEnvironmentInfoPath
+    return this.http.get<EnvironmentInformation>(envUrl);
   }
 }
+

--- a/dfa-public/src/UI/embc-dfa/src/assets/env/info.json
+++ b/dfa-public/src/UI/embc-dfa/src/assets/env/info.json
@@ -1,0 +1,14 @@
+{
+  "envName": "local",
+  "bannerTitle": "You are in the LOCAL version of the Public Disaster Financial Assistance Tool.",
+  "bannerSubTitle": "All information entered here will be treated as LOCAL data.",
+  "bannerColor": "#097d8c",
+  "startDisplayOutageBanner": "2025-03-28T05:00:00-08:00",
+  "outageStart": "2025-03-25T05:00:00-08:00",
+  "outageEnd": "2025-03-29T05:00:00-08:00",
+  "dfaPublicUrl": "https://publicsector-dev.dfa.gov.bc.ca/registration-method",
+  "dfaPrivateUrl": "https://portal.dev.dfa.gov.bc.ca/registration-method",
+  "disablePublicUrl": false,
+  "disablePrivateUrl": false,
+  "newApplicationNotAccepted": false
+}


### PR DESCRIPTION
Adding environment banner for Public DFA Sector.

![image](https://github.com/user-attachments/assets/54109e60-46e6-408b-8561-b340768d966c)

_Note: Confirmed config.json is included in OCP for all environments in the `configMap`._

[Story](https://emcr.atlassian.net/browse/DFA-64)