### PR TITLE
DEVOPS-413a: Set max upload limit to 45MB and made various minor adju…

### DIFF
--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using System.Xml;
@@ -21,6 +22,7 @@ using Org.BouncyCastle.Asn1.Mozilla;
 using Pipelines.Sockets.Unofficial.Arenas;
 using Xrm.Tools.WebAPI;
 using Xrm.Tools.WebAPI.Requests;
+using Xrm.Tools.WebAPI.Results;
 using static System.Net.Mime.MediaTypeNames;
 
 namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
@@ -790,21 +792,48 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
             }
         }
 
+        // TODO this method should be used to parse all responses from api.ExecuteAction(), see InsertS3DocumentAsync() for usage
+        public async Task<Dictionary<string, object>> ExecuteActionAsync(
+            string actionName,
+            object data,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var response = await api.ExecuteAction(actionName, data);
+
+                if (response is ExpandoObject expando)
+                {
+                    return new Dictionary<string, object>((IDictionary<string, object>)expando);
+                }
+
+                throw new InvalidCastException("Expected ExpandoObject in ExecuteActionAsync response.");
+            }
+            catch (Exception ex)
+            {
+                // Add more context to the error
+                throw new Exception($"Error executing CRM action '{actionName}': {ex.Message}", ex);
+            }
+        }
+
         public async Task<string> InsertS3DocumentAsync(S3SubmissionEntity submission)
         {
             try
             {
-                var result = await api.ExecuteAction("dfa_UploadDocumentToS3andCreateDocumentMetadata", submission);
+                // Call ExecuteActionAsync and get the result as a dictionary
+                var result = await ExecuteActionAsync("dfa_UploadDocumentToS3andCreateDocumentMetadata", submission);
 
-                if (result != null)
+                // Look for the "DocumentMetadataId" key and return its value if found
+                if (result.TryGetValue("DocumentMetadataId", out var documentMetadataId) &&
+                    documentMetadataId != null)
                 {
-                    return result.Where(m => m.Key == "DocumentMetadataId") != null ? result.Where(m => m.Key == "DocumentMetadataId").ToList()[0].Value?.ToString() : string.Empty;
-                }
+                    return documentMetadataId.ToString();
+                } 
                 return "Submitted";
             }
             catch (Exception ex)
             {
-                throw new Exception($"Failed to insert S3 document {ex.Message}", ex);
+                throw new Exception($"Failed to insert S3 document: {ex.Message}", ex);
             }
         }
 

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/AttachmentController.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/AttachmentController.cs
@@ -20,6 +20,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.IdentityModel.Tokens;
 using Namotion.Reflection;
 using Org.BouncyCastle.Asn1.Ocsp;
+using Microsoft.Extensions.Logging;
 using Pipelines.Sockets.Unofficial.Arenas;
 
 namespace EMBC.DFA.API.Controllers
@@ -33,12 +34,15 @@ namespace EMBC.DFA.API.Controllers
         private readonly IHostEnvironment env;
         private readonly IMapper mapper;
         private readonly IConfigurationHandler handler;
+
+        private readonly ILogger logger;
         // 2024-08-15 EMCRI-595 waynezen; BCeID Authentication
         private readonly IUserService userService;
         private readonly IS3Provider s3Provider;
         private readonly ErrorParser errorParser;
 
-        private static readonly int MAXFILESIZE = 104857600;
+        // Max file upload in bytes
+        private const int MAXFILESIZE = 100 * 1_048_576;   // MB
 
         public AttachmentController(
             IConfiguration configuration,
@@ -46,7 +50,8 @@ namespace EMBC.DFA.API.Controllers
             IMapper mapper,
             IConfigurationHandler handler,
             IUserService userService,
-            IS3Provider s3Provider)
+            IS3Provider s3Provider,
+            ILoggerFactory factory)
         {
             this.configuration = configuration;
             this.env = env;
@@ -55,6 +60,7 @@ namespace EMBC.DFA.API.Controllers
             this.userService = userService ?? throw new ArgumentNullException(nameof(userService));
             this.s3Provider = s3Provider;
             this.errorParser = new ErrorParser();
+            logger = factory.CreateLogger<AttachmentController>();
         }
 
         private string currentUserId => userService.GetBCeIDBusinessId();
@@ -101,7 +107,7 @@ namespace EMBC.DFA.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [RequestSizeLimit(104857600)]
+        [RequestSizeLimit(MAXFILESIZE)]
         public async Task<ActionResult<string>> UpsertDeleteProjectAttachment(FileUpload fileUpload)
         {
             if (fileUpload.fileData == null && fileUpload.deleteFlag == false) return BadRequest("FileUpload data cannot be empty.");
@@ -123,9 +129,10 @@ namespace EMBC.DFA.API.Controllers
                 }
                 else
                 {
+                    logger.LogInformation("Upload S3 attachments dfa_project");
                     if (fileUpload.fileSize >= MAXFILESIZE)
                     {
-                        throw new Exception("File size exceeds 100MB limit");
+                        throw new Exception($"File size exceeds {MAXFILESIZE / 1_048_576.0:F2}MB limit");
                     }
 
                     var submissionEntity = mapper.Map<S3SubmissionEntity>(fileUpload);
@@ -143,8 +150,16 @@ namespace EMBC.DFA.API.Controllers
                         recoveryClaim : dfa_recoveryclaim */
                     submissionEntity.RegardingEntityLookUpFieldName = "dfa_project";
 
-                    var result = await handler.HandleS3FileUploadAsync(submissionEntity);
-                    return Ok(result);
+                    try
+                    {
+                        var result = await handler.HandleS3FileUploadAsync(submissionEntity);
+                        return Ok(result);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Failed to upload file to S3.");
+                        return StatusCode(StatusCodes.Status500InternalServerError, "An error occurred while uploading file.");
+                    }
                 }
             }
             else
@@ -183,7 +198,7 @@ namespace EMBC.DFA.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [RequestSizeLimit(104857600)]
+        [RequestSizeLimit(MAXFILESIZE)]
         public async Task<ActionResult<string>> UpsertDeleteClaimAttachment(FileUploadClaim fileUpload)
         {
             if (fileUpload.fileData == null && fileUpload.deleteFlag == false) return BadRequest("FileUpload data cannot be empty.");
@@ -205,9 +220,10 @@ namespace EMBC.DFA.API.Controllers
                 }
                 else
                 {
+                    logger.LogInformation("Upload S3 attachments dfa_projectclaim");
                     if (fileUpload.fileSize >= MAXFILESIZE)
                     {
-                        throw new Exception("File size exceeds 100MB limit");
+                        throw new Exception($"File size exceeds {MAXFILESIZE / 1_048_576.0:F2}MB limit");
                     }
 
                     var submissionEntity = mapper.Map<S3SubmissionEntity>(fileUpload);
@@ -225,8 +241,16 @@ namespace EMBC.DFA.API.Controllers
                         recoveryClaim : dfa_recoveryclaim */
                     submissionEntity.RegardingEntityLookUpFieldName = "dfa_recoveryclaim";
 
-                    var result = await handler.HandleS3FileUploadAsync(submissionEntity);
-                    return Ok(result);
+                    try
+                    {
+                        var result = await handler.HandleS3FileUploadAsync(submissionEntity);
+                        return Ok(result);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.LogError(ex, "Failed to upload file to S3.");
+                        return StatusCode(StatusCodes.Status500InternalServerError, "An error occurred while uploading file.");
+                    }
                 }
             }
             else

--- a/dfa-public/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.html
@@ -17,7 +17,7 @@
   <p class="file-format">Restricted characters in file name:</p>
   <p class="invalid-characters">
     ~ " # % & * : . &lt; &gt; ? / &#123; | &#125;. Leading and trailing spaces
-    in file name aren't allowed.
+    in file name aren't allowed. The maximum file size is {{ maxFileSize / 1048576 | number:'1.2-2' }}MB.
   </p>
 </div>
 <div *ngIf="attachSizeError" style="color: red">

--- a/dfa-public/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.scss
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.scss
@@ -1,5 +1,5 @@
 .drag-drop {
-  height: 230px;
+  height: 250px;
   padding: 2rem;
   text-align: center;
   border: dashed 1px #C4C4C4;

--- a/dfa-public/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.ts
@@ -15,7 +15,7 @@ export class FileUploadComponent {
   @Input() allowedFileExtensionsList: string;
   fileAttachments: string[] = [];
   attachSizeError = false;
-  maxFileSize: number = 52428800;
+  maxFileSize: number = 45 * 1024 * 1024; //MB
 
   constructor(
     public dialog: MatDialog
@@ -35,7 +35,7 @@ export class FileUploadComponent {
       if (!(e.size > 0)) {
         this.warningDialog(constant.zeroFileMessage);
       } else if (!(e.size <= this.maxFileSize)) {
-        this.warningDialog(constant.fileTooLargeMessage);
+        this.warningDialog(`${constant.fileTooLargeMessage}${(this.maxFileSize / 1048576).toFixed(2)}MB`);
       } else if (!this.allowedFileTypes?.includes(e.type)) {
         this.warningDialog(constant.fileTypeMessage);
       } else if (!constant.fileNameFormat.test(e.name)) {

--- a/dfa-public/src/UI/embc-dfa/src/app/core/services/globalConstants.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/core/services/globalConstants.ts
@@ -243,7 +243,7 @@ export const supportStatusListError =
   'Unable to save application at this time. Please try again later';
 
 export const zeroFileMessage = 'Attachment file size must be greater than 0Kb';
-export const fileTooLargeMessage = 'Attachment file size must not be more than 50MB';
+export const fileTooLargeMessage = 'Attachment file size must not be more than ';
 export const fileTypeMessage = 'Invalid file type.';
 export const fileNameFormat = /^[\w,\s-_()]+\.[A-Za-z]{3,4}$/;
 export const invalidFileNameMessage =

--- a/dfa/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
+++ b/dfa/src/API/EMBC.DFA.API/ConfigurationModule/Models/Dynamics/DynamicsGateway.cs
@@ -4,6 +4,7 @@ using System.Dynamic;
 using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
 using System.Xml;
@@ -698,21 +699,48 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.Dynamics
             }
         }
 
+        // TODO this method should be used to parse all responses from api.ExecuteAction(), see InsertS3DocumentAsync() for usage
+        public async Task<Dictionary<string, object>> ExecuteActionAsync(
+            string actionName,
+            object data,
+            CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                var response = await api.ExecuteAction(actionName, data);
+
+                if (response is ExpandoObject expando)
+                {
+                    return new Dictionary<string, object>((IDictionary<string, object>)expando);
+                }
+
+                throw new InvalidCastException("Expected ExpandoObject in ExecuteActionAsync response.");
+            }
+            catch (Exception ex)
+            {
+                // Add more context to the error
+                throw new Exception($"Error executing CRM action '{actionName}': {ex.Message}", ex);
+            }
+        }
+
         public async Task<string> InsertS3DocumentAsync(S3SubmissionEntity submission)
         {
             try
             {
-                var result = await api.ExecuteAction("dfa_UploadDocumentToS3andCreateDocumentMetadata", submission);
+                // Call ExecuteActionAsync and get the result as a dictionary
+                var result = await ExecuteActionAsync("dfa_UploadDocumentToS3andCreateDocumentMetadata", submission);
 
-                if (result != null)
+                // Look for the "DocumentMetadataId" key and return its value if found
+                if (result.TryGetValue("DocumentMetadataId", out var documentMetadataId) &&
+                    documentMetadataId != null)
                 {
-                    return result.Where(m => m.Key == "DocumentMetadataId") != null ? result.Where(m => m.Key == "DocumentMetadataId").ToList()[0].Value?.ToString() : string.Empty;
+                    return documentMetadataId.ToString();
                 }
                 return "Submitted";
             }
             catch (Exception ex)
             {
-                throw new Exception($"Failed to insert S3 document {ex.Message}", ex);
+                throw new Exception($"Failed to insert S3 document: {ex.Message}", ex);
             }
         }
 

--- a/dfa/src/API/EMBC.DFA.API/Controllers/AttachmentController.cs
+++ b/dfa/src/API/EMBC.DFA.API/Controllers/AttachmentController.cs
@@ -28,7 +28,8 @@ namespace EMBC.DFA.API.Controllers
         private readonly IConfigurationHandler handler;
         private readonly ILogger logger;
 
-        private static readonly int MAXFILESIZE = 104857600;
+        // Max file upload in bytes
+        private const int MAXFILESIZE = 100 * 1_048_576; // MB
 
         public AttachmentController(
             IConfiguration configuration,
@@ -55,7 +56,7 @@ namespace EMBC.DFA.API.Controllers
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [RequestSizeLimit(104857600)]
+        [RequestSizeLimit(MAXFILESIZE)]
         public async Task<ActionResult<string>> UpsertDeleteAttachment(FileUpload fileUpload)
         {
             if (fileUpload.fileData == null && fileUpload.deleteFlag == false) return BadRequest("FileUpload data cannot be empty.");
@@ -88,9 +89,10 @@ namespace EMBC.DFA.API.Controllers
                 }
                 else
                 {
+                    logger.LogInformation("Upload S3 attachments dfa_appapplication");
                     if (fileUpload.fileSize >= MAXFILESIZE)
                     {
-                        throw new Exception("File size exceeds 100MB limit");
+                        throw new Exception($"File size exceeds {MAXFILESIZE / 1_048_576.0:F2}MB limit");
                     }
 
                     var submissionEntity = mapper.Map<S3SubmissionEntity>(fileUpload);
@@ -107,25 +109,16 @@ namespace EMBC.DFA.API.Controllers
                         project : dfa_project
                         recoveryClaim : dfa_recoveryclaim */
                     submissionEntity.RegardingEntityLookUpFieldName = "dfa_appapplication";
-                    string result = "Submitted";
 
                     try
                     {
-                        result = await handler.HandleS3FileUploadAsync(submissionEntity);
+                        var result = await handler.HandleS3FileUploadAsync(submissionEntity);
+                        return Ok(result);
                     }
                     catch (Exception ex)
                     {
-                        error = true;
-                        logger.LogError(ex, "Error uploading file");
-                    }
-
-                    if (error)
-                    {
-                        return StatusCode(500, "Error uploading file");
-                    }
-                    else
-                    {
-                        return Ok(result);
+                        logger.LogError(ex, "Failed to upload file to S3.");
+                        return StatusCode(StatusCodes.Status500InternalServerError, "An error occurred while uploading file.");
                     }
                 }
             }

--- a/dfa/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.html
+++ b/dfa/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.html
@@ -17,7 +17,7 @@
   <p class="file-format">Restricted characters in file name:</p>
   <p class="invalid-characters">
     ~ " # % & * : . &lt; &gt; ? / &#123; | &#125;. Leading and trailing spaces
-    in file name aren't allowed. The maximum file size is 25MB.
+    in file name aren't allowed. The maximum file size is {{ maxFileSize / 1048576 | number:'1.2-2' }}MB.
   </p>
 </div>
 <div *ngIf="attachSizeError" style="color: red">

--- a/dfa/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/core/components/file-upload/file-upload.component.ts
@@ -16,7 +16,7 @@ export class FileUploadComponent {
   @Input() allowedFileExtensionsList: string;
   fileAttachments: string[] = [];
   attachSizeError = false;
-  maxFileSize: number = 52428800;
+  maxFileSize: number = 45 * 1024 * 1024;  // MB
 
   constructor(
     public dialog: MatDialog
@@ -36,7 +36,7 @@ export class FileUploadComponent {
       if (!(e.size > 0)) {
         this.warningDialog(constant.zeroFileMessage);
       } else if (!(e.size <= this.maxFileSize)) {
-        this.warningDialog(constant.fileTooLargeMessage);
+        this.warningDialog(`${constant.fileTooLargeMessage}${(this.maxFileSize / 1048576).toFixed(2)}MB`);
       } else if (!this.allowedFileTypes?.includes(e.type)) {
         this.warningDialog(constant.fileTypeMessage);
       } else if (!constant.fileNameFormat.test(e.name)) {

--- a/dfa/src/UI/embc-dfa/src/app/core/services/globalConstants.ts
+++ b/dfa/src/UI/embc-dfa/src/app/core/services/globalConstants.ts
@@ -217,7 +217,7 @@ export const supportStatusListError =
   'Unable to save application at this time. Please try again later';
 
 export const zeroFileMessage = 'Attachment file size must be greater than 0Kb';
-export const fileTooLargeMessage = 'Attachment file size must not be more than 50MB';
+export const fileTooLargeMessage = 'Attachment file size must not be more than ';
 export const fileTypeMessage = 'Invalid file type.';
 export const fileNameFormat = /^[\w,\s-_()]+\.[A-Za-z]{3,4}$/;
 export const invalidFileNameMessage =


### PR DESCRIPTION
…stments

We had to change the desired limit of 50MB as max file upload size to 45MB. 
Erin, agreed to the change.

The reason we cannot go to 50MB is due to the Dynamics implementation interface with S3, it fails with a 50MB file when using the DFA public  dynamics workflows. Note: DFA private dynamics workflow worked. 

If there is need to increment this limit sometime down the road we will need to sort out the issue in dynamics or re-architect the flow so the S3 API goes directly to S3 as opposed to use dynamics as a proxy.