### PR TITLE
D4P-167: Added initial projects appeal timeline

### DIFF
--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.html
@@ -183,7 +183,7 @@
         </div>
       </div>
 
-      <div style="display: flex; margin-top:30px">
+      <div style="display: flex; margin:30px 30px;">
         <div class="col-md-12">
           <span *ngIf="applItem.isErrorInStatus == true" style="color: red;">Error in displaying status<br /><br /></span>
           <table cellpadding="0" cellspacing="0">
@@ -223,21 +223,53 @@
           </table>
         </div>
       </div>
-      <div [featureEnabled]="'useAppeals'" style="display: flex; margin-top:30px">
-        <div class="col-md-12" style="display: flex; justify-content: flex-end; padding-right:32px">
+      <div [featureEnabled]="'useAppeals'" style="margin-top: 30px; border-top: 1px solid lightgrey; padding-top: 30px;">
+        <div style="display: flex; margin:30px 30px;">
+          <div class="col-md-12">
+            <table cellpadding="0" cellspacing="0">
+              <tr>
+                <td colspan="3" *ngFor="let item of getItems(applItem.appealStatusBar); let i=index" id="item{{i}}" [ngClass]="'headerlabelStyle'">
+                  <span *ngIf="item.status != ''" class="stepText">{{item.status}}</span>
+                </td>
+              </tr>
+              <tr>
+                <td *ngFor="let item of applItem.appealStatusBar; let i=index" id="item{{i}}" [ngClass]="item.status != '' ? 'labelStyle' : 'labelEmptyWidth'">
+                  <div *ngIf="item.status != ''" [ngClass]="item.currentStep == false || item.status == 'Closed' ? 'alignStatus' : 'alignStatus'">
+                    <span *ngIf="item.isCompleted == false && item.currentStep == true && item.stage != ''" class="material-symbols-outlined" style="color: #FDCB52">
+                      circle
+                    </span>
+                    <span *ngIf="item.isCompleted == false && item.currentStep == false" class="material-symbols-outlined" style="color: #FDCB52">
+                      circle
+                    </span>
+                  </div>
+                  <div class="lineConnector" *ngIf="item.status == '' && i > 1 && (i+1) < applItem.appealStatusBar.length"></div>
+                </td>
+              </tr>
+            </table>
+          </div>
+        </div>
+        <div class="col-md-12" style="display: flex; justify-content: flex-end; padding-right: 32px;">
           <div class="button-column">
             <button
               [class]="appealButtonClass(applItem)"
               (click)="appealDecision(applItem)"
               type="button"
               [disabled]="!canAppeal(applItem)"
-              [title]="appealButtonTitle(applItem)">Appeal Decision
+              [title]="appealButtonTitle(applItem)"
+            >
+              Appeal Decision
             </button>
           </div>
         </div>
-      </div>
-      <div [featureEnabled]="'useAppeals'" *ngIf="canAppeal(applItem)" class="col-md-12" style="display: flex; justify-content: flex-end; padding: 10px 32px 0 0;">
-        <span>Project Approval decision can be appealed for {{ remainingDays(applItem) }} days</span>
+        <div
+          *ngIf="canAppeal(applItem)"
+          class="col-md-12"
+          style="display: flex; justify-content: flex-end; padding: 10px 32px 0 0;"
+        >
+          <span>
+            Project Approval decision can be appealed for {{ remainingDays(applItem) }} days
+          </span>
+        </div>
       </div>
     </mat-card>
   </div>

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.ts
@@ -12,6 +12,23 @@ import { DFAProjectMainDataService } from '../../../feature-components/dfa-proje
 import { DFAClaimMainDataService } from '../../../feature-components/dfa-claim-main/dfa-claim-main-data.service';
 import { Decision } from 'src/app/models/decision.enum';
 
+// Temporary extension until the OpenAPI spec includes appealStatusBar
+// ####################################################################
+interface CurrentProjectWithAppeals extends CurrentProject {
+  appealStatusBar?: AppealStatusItem[]; // Replace with actual type if available
+}
+
+interface AppealStatusItem {
+  status: string;
+  statusColor?: string;
+  currentStep?: boolean;
+  stage?: string;
+  isCompleted?: boolean;
+  isFinalStep?: boolean;
+}
+// ####################################################################
+
+
 @Component({
   selector: 'app-dfadashboard-project',
   templateUrl: './project.component.html',
@@ -47,9 +64,32 @@ export class DfaDashProjectComponent implements OnInit {
     { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
 
   ];
+
+  appealItems = [
+    // { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    // { status: "Draft", stage: "", statusColor: "#639DD4", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    // { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "Submitted", stage: "", statusColor: "#FDCB52", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "Under Review", stage: "", statusColor: "#FDCB52", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "Approval Pending", stage: "", statusColor: "#FDCB52", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "Decision Made", stage: "", statusColor: "#62A370", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+    { status: "Closed", stage: "", statusColor: "#62A370", isCompleted: false, currentStep: false, isFinalStep: true, isErrorInStatus: false },
+    { status: "", stage: "", statusColor: "", isCompleted: false, currentStep: false, isFinalStep: false, isErrorInStatus: false },
+
+  ];
   lstProjects: ProjectExtended[] = [];
   lstFilteredProjects: ProjectExtended[] = [];
   matchStatusFound = false;
+  appealMatchStatusFound = false;
   isLinear = true;
   current = 1;
   appId = null;
@@ -90,8 +130,8 @@ export class DfaDashProjectComponent implements OnInit {
           var initialList = lstData;
           lstDataUnModified.push(initialList);
           lstData.forEach(objApp => {
-            var isFound = false;
-            var jsonVal = JSON.stringify(this.items);
+            let isFound = false;
+            const jsonVal = JSON.stringify(this.items);
             objApp.isErrorInStatus = false;
             objApp.statusBar = JSON.parse(jsonVal);
             objApp.statusBar.forEach(objStatItem => {
@@ -138,6 +178,63 @@ export class DfaDashProjectComponent implements OnInit {
               }
 
             });
+
+            // This code needs to be updated once the Dynamics API sends the appealStatusBar in the response
+            // #############################################################################################
+            const objAppWithAppeals = objApp as CurrentProjectWithAppeals;
+
+            // Initialize appealStatusBar if it's missing
+            if (!Array.isArray(objAppWithAppeals.appealStatusBar)) {
+              objAppWithAppeals.appealStatusBar = JSON.parse(JSON.stringify(this.appealItems));
+            }
+
+            objAppWithAppeals.appealStatusBar.forEach((objStatItem) => {
+              const statusMatch =
+                objApp.status &&
+                objStatItem.status?.toLowerCase() === objApp.status.toLowerCase();
+
+              if (statusMatch) {
+                objStatItem.currentStep = true;
+                isFound = true;
+                this.matchStatusFound = true;
+
+                if (objApp.stage) {
+                  objStatItem.stage = objApp.stage;
+                  this.dFAProjectMainDataService.setStage(objApp.stage);
+                }
+
+                if (objApp.projectDecision) {
+                  this.dFAProjectMainDataService.setProjectDecision(objApp.projectDecision);
+                }
+
+                // Determine statusColor based on logic
+                if (['Ineligible', 'Withdrawn'].includes(objApp.stage || '')) {
+                  objApp.statusColor = '#E25E63';
+                } else if (
+                  objApp.status?.toLowerCase().includes('decision made') &&
+                  objApp.stage?.toLowerCase().includes('progress')
+                ) {
+                  objApp.statusColor = '#FDCB52';
+                } else {
+                  objApp.statusColor = objStatItem.statusColor;
+                }
+              }
+
+              // Fallback if status not matched
+              if (!isFound) {
+                objStatItem.isCompleted = true;
+              }
+
+              // Final step validation
+              if (objStatItem.isFinalStep) {
+                if (!isFound) {
+                  objApp.isErrorInStatus = true;
+                } else if (statusMatch) {
+                  objStatItem.isCompleted = true;
+                }
+              }
+            });
+            // #############################################################################################
 
             lstDataModified.push(objApp);
           })


### PR DESCRIPTION
Added initial timeline display for project appeals in the UI.

Note: The appealStatusBar property has not yet been implemented in the Dynamics API response. As a temporary workaround, the CurrentProject interface has been extended locally to mock this property. The timeline renders with default values and no dynamic status progression. This is a short-term solution until the OpenAPI spec is updated to include appealStatusBar.