### PR TITLE
D4P-226: Improve Claim Invoice SCSS

### DIFF
--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/dfa-invoice-dashboard/dfa-invoice-dashboard.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/dfa-invoice-dashboard/dfa-invoice-dashboard.component.ts
@@ -481,8 +481,8 @@ export default class DFAInvoiceDashboardComponent implements OnInit, OnDestroy {
           claimDecision: this.dfaClaimMainDataService.getClaimDecision(),
           header: 'View'
         },
-        maxHeight: '90vh',
-        maxWidth: '80vw',
+        height: '665px',
+        width: '1200px',
         disableClose: true
       })
       .afterClosed()
@@ -504,8 +504,8 @@ export default class DFAInvoiceDashboardComponent implements OnInit, OnDestroy {
           invoiceId: this.dfaClaimMainDataService.getInvoiceId(),
           claimDecision: this.dfaClaimMainDataService.getClaimDecision()
         },
-        maxHeight: '90vh',
-        maxWidth: '80vw',
+        height: '665px',
+        width: '1200px',
         disableClose: true
       })
       .afterClosed()

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/invoice/invoice.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/invoice/invoice.component.html
@@ -1,7 +1,12 @@
-<mat-card class="card-align recoveryPlan" style="border: none" [class.mat-elevation-z0]="true">
-  <mat-card-content>
+<mat-card class="card-container recoveryPlan" [class.mat-elevation-z0]="true">
+  <mat-card-header class="card-header-container">
+    <div class="row">
+      <h1 #invHeadr id="invHeadr" class="m-0">{{ addeditInvoiceText }} Invoice</h1>
+    </div>
+  </mat-card-header>
+
+  <mat-card-content class="card-content-container">
     <form [formGroup]="invoiceForm">
-      <h1 #invHeadr id="invHeadr" class="header-align-inv">{{ addeditInvoiceText }} Invoice</h1>
       <button
         type="button"
         #tooltip="matTooltip"
@@ -14,12 +19,57 @@
         <span class="ques">?</span>&nbsp; HELP
       </button>
 
-      <ng-container>
-        <div class="row">
-          <div class="col-md-6">
+      <div class="row">
+        <div class="col-md-6">
+          <div class="row" *ngIf="isReadOnly === true">
+            <div class="col-md-6">
+              <p style="font-size: 15px">EMCR Decision</p>
+              @if (
+                claimDecision == DecisionEnum.Approved ||
+                claimDecision == DecisionEnum.ApprovedWithExclusions ||
+                claimDecision == DecisionEnum.Ineligible ||
+                claimDecision == DecisionEnum.Withdrawn
+              ) {
+                <mat-form-field appearance="outline">
+                  <input #emcrDecision formControlName="emcrDecision" matInput />
+                </mat-form-field>
+              } @else {
+                <mat-form-field appearance="outline">
+                  <input matInput readonly disabled="true" />
+                </mat-form-field>
+              }
+            </div>
+
+            <div class="col-md-6">
+              <p style="font-size: 15px">EMCR Approved Amount</p>
+
+              @if (claimDecision == DecisionEnum.Approved || claimDecision == DecisionEnum.ApprovedWithExclusions) {
+                <mat-form-field appearance="outline" class="mat-form-round">
+                  <div class="searchDiv">
+                    <input
+                      #currencyBoxemcrApprovedAmount
+                      id="currencyBoxemcrApprovedAmount"
+                      formControlName="emcrApprovedAmount"
+                      matInput
+                      mask="separator.2"
+                      thousandSeparator=","
+                      decimalMarker="." />
+                    <span class="currencyText">CA$</span>
+                  </div>
+                </mat-form-field>
+              } @else {
+                <mat-form-field appearance="outline" class="mat-form-round">
+                  <div class="searchDiv">
+                    <input matInput readonly disabled="true" />
+                    <span class="currencyText">CA$</span>
+                  </div>
+                </mat-form-field>
+              }
+            </div>
+
             <div class="row" *ngIf="isReadOnly === true">
               <div class="col-md-6">
-                <p style="font-size: 15px">EMCR Decision</p>
+                <p style="font-size: 15px">EMCR Decision Date</p>
                 @if (
                   claimDecision == DecisionEnum.Approved ||
                   claimDecision == DecisionEnum.ApprovedWithExclusions ||
@@ -27,419 +77,372 @@
                   claimDecision == DecisionEnum.Withdrawn
                 ) {
                   <mat-form-field appearance="outline">
-                    <input #emcrDecision formControlName="emcrDecision" matInput />
+                    <input
+                      matInput
+                      [matDatepicker]="decisionDatePicker"
+                      [readonly]="isReadOnly === true"
+                      formControlName="decisionDate" />
+                    <mat-hint *ngIf="isReadOnly !== true">MM/DD/YYYY</mat-hint>
+                    <mat-datepicker-toggle
+                      matSuffix
+                      [for]="decisionDatePicker"
+                      [disabled]="isReadOnly === true"></mat-datepicker-toggle>
+                    <mat-datepicker #decisionDatePicker [disabled]="isReadOnly === true"></mat-datepicker>
                   </mat-form-field>
                 } @else {
                   <mat-form-field appearance="outline">
                     <input matInput readonly disabled="true" />
+                    <mat-datepicker #decisionDatePicker [disabled]="isReadOnly === true"></mat-datepicker>
                   </mat-form-field>
                 }
               </div>
+            </div>
 
-              <div class="col-md-6">
-                <p style="font-size: 15px">EMCR Approved Amount</p>
-
-                @if (claimDecision == DecisionEnum.Approved || claimDecision == DecisionEnum.ApprovedWithExclusions) {
-                  <mat-form-field appearance="outline" class="mat-form-round">
-                    <div class="searchDiv">
-                      <input
-                        #currencyBoxemcrApprovedAmount
-                        id="currencyBoxemcrApprovedAmount"
-                        formControlName="emcrApprovedAmount"
-                        matInput
-                        mask="separator.2"
-                        thousandSeparator=","
-                        decimalMarker="." />
-                      <span class="currencyText">CA$</span>
-                    </div>
+            <div class="row" *ngIf="isReadOnly === true">
+              <p style="font-size: 15px">EMCR Decision Comments</p>
+              <div class="col-md-12">
+                @if (
+                  claimDecision == DecisionEnum.Approved ||
+                  claimDecision == DecisionEnum.ApprovedWithExclusions ||
+                  claimDecision == DecisionEnum.Ineligible ||
+                  claimDecision == DecisionEnum.Withdrawn
+                ) {
+                  <mat-form-field appearance="outline">
+                    <textarea
+                      [disabled]="isReadOnly"
+                      matInput
+                      formControlName="emcrDecisionComments"
+                      style="resize: none"
+                      cdkTextareaAutosize
+                      #autosize="cdkTextareaAutosize"
+                      cdkAutosizeMinRows="2"
+                      cdkAutosizeMaxRows="5"></textarea>
                   </mat-form-field>
                 } @else {
-                  <mat-form-field appearance="outline" class="mat-form-round">
-                    <div class="searchDiv">
-                      <input matInput readonly disabled="true" />
-                      <span class="currencyText">CA$</span>
-                    </div>
+                  <mat-form-field appearance="outline">
+                    <textarea
+                      matInput
+                      readonly
+                      disabled="true"
+                      style="resize: none"
+                      cdkTextareaAutosize
+                      #autosize="cdkTextareaAutosize"
+                      cdkAutosizeMinRows="2"
+                      cdkAutosizeMaxRows="5"></textarea>
                   </mat-form-field>
                 }
-              </div>
-
-              <div class="row" *ngIf="isReadOnly === true">
-                <div class="col-md-6">
-                  <p style="font-size: 15px">EMCR Decision Date</p>
-                  @if (
-                    claimDecision == DecisionEnum.Approved ||
-                    claimDecision == DecisionEnum.ApprovedWithExclusions ||
-                    claimDecision == DecisionEnum.Ineligible ||
-                    claimDecision == DecisionEnum.Withdrawn
-                  ) {
-                    <mat-form-field appearance="outline">
-                      <input
-                        matInput
-                        [matDatepicker]="decisionDatePicker"
-                        [readonly]="isReadOnly === true"
-                        formControlName="decisionDate" />
-                      <mat-hint *ngIf="isReadOnly !== true">MM/DD/YYYY</mat-hint>
-                      <mat-datepicker-toggle
-                        matSuffix
-                        [for]="decisionDatePicker"
-                        [disabled]="isReadOnly === true"></mat-datepicker-toggle>
-                      <mat-datepicker #decisionDatePicker [disabled]="isReadOnly === true"></mat-datepicker>
-                    </mat-form-field>
-                  } @else {
-                    <mat-form-field appearance="outline">
-                      <input matInput readonly disabled="true" />
-                      <mat-datepicker #decisionDatePicker [disabled]="isReadOnly === true"></mat-datepicker>
-                    </mat-form-field>
-                  }
-                </div>
-              </div>
-
-              <div class="row" *ngIf="isReadOnly === true">
-                <p style="font-size: 15px">EMCR Decision Comments</p>
-                <div class="col-md-12">
-                  @if (
-                    claimDecision == DecisionEnum.Approved ||
-                    claimDecision == DecisionEnum.ApprovedWithExclusions ||
-                    claimDecision == DecisionEnum.Ineligible ||
-                    claimDecision == DecisionEnum.Withdrawn
-                  ) {
-                    <mat-form-field appearance="outline">
-                      <textarea
-                        [disabled]="isReadOnly"
-                        matInput
-                        formControlName="emcrDecisionComments"
-                        style="resize: none"
-                        cdkTextareaAutosize
-                        #autosize="cdkTextareaAutosize"
-                        cdkAutosizeMinRows="2"
-                        cdkAutosizeMaxRows="5"></textarea>
-                    </mat-form-field>
-                  } @else {
-                    <mat-form-field appearance="outline">
-                      <textarea
-                        matInput
-                        readonly
-                        disabled="true"
-                        style="resize: none"
-                        cdkTextareaAutosize
-                        #autosize="cdkTextareaAutosize"
-                        cdkAutosizeMinRows="2"
-                        cdkAutosizeMaxRows="5"></textarea>
-                    </mat-form-field>
-                  }
-                  <br />
-                </div>
-              </div>
-            </div>
-
-            <hr class="hr-align" *ngIf="isReadOnly === true" />
-            <div class="row">
-              <div class="col-md-12">
-                <p style="font-size: 15px">Vendor Name<span style="color: red">*</span></p>
-                <mat-form-field appearance="outline">
-                  <input #vendorName formControlName="vendorName" matInput required maxlength="100" />
-                </mat-form-field>
-              </div>
-            </div>
-            <div class="row">
-              <div class="col-md-6">
-                <p style="font-size: 15px">Invoice Number<span style="color: red">*</span></p>
-                <mat-form-field appearance="outline" class="mat-form-round">
-                  <input id="invoiceNumber" formControlName="invoiceNumber" matInput required maxlength="100" />
-                </mat-form-field>
-              </div>
-              <div class="col-md-6">
-                <p style="font-size: 15px">Invoice Date<span style="color: red">*</span></p>
-                <mat-form-field appearance="outline">
-                  <mat-label>Invoice Date</mat-label>
-                  <input
-                    matInput
-                    (focusin)="setHelpText(1, tooltip)"
-                    [matDatepicker]="invoiceDatePicker"
-                    [readonly]="isReadOnly === true"
-                    formControlName="invoiceDate"
-                    required />
-                  <mat-hint *ngIf="isReadOnly !== true">MM/DD/YYYY</mat-hint>
-                  <mat-datepicker-toggle
-                    matSuffix
-                    [for]="invoiceDatePicker"
-                    [disabled]="isReadOnly === true"></mat-datepicker-toggle>
-                  <mat-datepicker #invoiceDatePicker [disabled]="isReadOnly === true"></mat-datepicker>
-                </mat-form-field>
-              </div>
-              <div class="col-md-1"></div>
-            </div>
-            <br />
-            <div class="row">
-              <div class="col-md-12">
-                <p style="font-size: 15px">
-                  Is the date that the goods or services were received the same as the invoice date?<span
-                    style="color: red"
-                    >*</span
-                  >
-                </p>
-                <mat-radio-group
-                  formControlName="isGoodsReceivedonInvoiceDate"
-                  class="primary-radio-group horizontal-radio-group"
-                  aria-label="Select an option">
-                  <mat-radio-button value="true">Yes</mat-radio-button>&nbsp;&nbsp;<mat-radio-button value="false"
-                    >No</mat-radio-button
-                  >
-
-                  <mat-error
-                    *ngIf="
-                      invoiceForm.get('isGoodsReceivedonInvoiceDate').invalid &&
-                      invoiceForm.get('isGoodsReceivedonInvoiceDate').hasError('required')
-                    ">
-                    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This is required
-                  </mat-error>
-                </mat-radio-group>
-              </div>
-            </div>
-            <br />
-
-            <div
-              class="row"
-              [hidden]="(formCreationService.invoiceForm$ | async)?.value.isGoodsReceivedonInvoiceDate != 'false'">
-              <p style="font-size: 15px">
-                Select the date that the goods or services were received<span style="color: red">*</span>
-              </p>
-              <div class="col-md-6">
-                <mat-form-field appearance="outline">
-                  <input
-                    matInput
-                    [matDatepicker]="goodsReceivedDatePicker"
-                    [readonly]="isReadOnly === true"
-                    formControlName="goodsReceivedDate" />
-                  <mat-hint *ngIf="isReadOnly !== true">MM/DD/YYYY</mat-hint>
-                  <mat-datepicker-toggle
-                    matSuffix
-                    [for]="goodsReceivedDatePicker"
-                    [disabled]="isReadOnly === true"></mat-datepicker-toggle>
-                  <mat-datepicker #goodsReceivedDatePicker [disabled]="isReadOnly === true"></mat-datepicker>
-                </mat-form-field>
-              </div>
-            </div>
-            <br *ngIf="(formCreationService.invoiceForm$ | async)?.value.isGoodsReceivedonInvoiceDate == 'false'" />
-            <div class="row">
-              <p style="font-size: 15px">Purpose of goods or services received<span style="color: red">*</span></p>
-              <div class="col-md-12">
-                <mat-form-field appearance="outline">
-                  <textarea
-                    [disabled]="isReadOnly"
-                    matInput
-                    formControlName="purposeOfGoodsServiceReceived"
-                    required
-                    style="resize: none"
-                    cdkTextareaAutosize
-                    #autosize="cdkTextareaAutosize"
-                    cdkAutosizeMinRows="2"
-                    cdkAutosizeMaxRows="5"
-                    maxlength="200"></textarea>
-                  <!--<mat-hint>{{ remainingLength }} characters remaining.</mat-hint>-->
-                </mat-form-field>
-
                 <br />
               </div>
             </div>
+          </div>
 
-            <div class="row">
-              <div class="col-md-12">
-                <p style="font-size: 15px">
-                  Are you claiming only a portion or part of the total invoice amount?<span style="color: red">*</span>
-                </p>
-                <mat-radio-group
-                  formControlName="isClaimforPartofTotalInvoice"
-                  class="primary-radio-group horizontal-radio-group"
-                  (change)="selectDamageDates($event)"
-                  aria-label="Select an option">
-                  <mat-radio-button value="true">Yes</mat-radio-button>&nbsp;&nbsp;<mat-radio-button value="false"
-                    >No</mat-radio-button
-                  >
-                  <mat-error *ngIf="invoiceForm.get('isClaimforPartofTotalInvoice').hasError('required')">
-                    &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This is required
-                  </mat-error>
-                </mat-radio-group>
-              </div>
+          <hr class="hr-align" *ngIf="isReadOnly === true" />
+          <div class="row">
+            <div class="col-md-12">
+              <p style="font-size: 15px">Vendor Name<span style="color: red">*</span></p>
+              <mat-form-field appearance="outline">
+                <input #vendorName formControlName="vendorName" matInput required maxlength="100" />
+              </mat-form-field>
             </div>
-            <br />
-            <div
-              class="row"
-              [hidden]="(formCreationService.invoiceForm$ | async)?.value.isClaimforPartofTotalInvoice != 'true'">
+          </div>
+          <div class="row">
+            <div class="col-md-6">
+              <p style="font-size: 15px">Invoice Number<span style="color: red">*</span></p>
+              <mat-form-field appearance="outline" class="mat-form-round">
+                <input id="invoiceNumber" formControlName="invoiceNumber" matInput required maxlength="100" />
+              </mat-form-field>
+            </div>
+            <div class="col-md-6">
+              <p style="font-size: 15px">Invoice Date<span style="color: red">*</span></p>
+              <mat-form-field appearance="outline">
+                <mat-label>Invoice Date</mat-label>
+                <input
+                  matInput
+                  (focusin)="setHelpText(1, tooltip)"
+                  [matDatepicker]="invoiceDatePicker"
+                  [readonly]="isReadOnly === true"
+                  formControlName="invoiceDate"
+                  required />
+                <mat-hint *ngIf="isReadOnly !== true">MM/DD/YYYY</mat-hint>
+                <mat-datepicker-toggle
+                  matSuffix
+                  [for]="invoiceDatePicker"
+                  [disabled]="isReadOnly === true"></mat-datepicker-toggle>
+                <mat-datepicker #invoiceDatePicker [disabled]="isReadOnly === true"></mat-datepicker>
+              </mat-form-field>
+            </div>
+            <div class="col-md-1"></div>
+          </div>
+          <br />
+          <div class="row">
+            <div class="col-md-12">
               <p style="font-size: 15px">
-                Please state why you are claiming only a portion of the total invoice<span style="color: red">*</span>
+                Is the date that the goods or services were received the same as the invoice date?<span
+                  style="color: red"
+                  >*</span
+                >
               </p>
-              <div class="col-md-12">
-                <mat-form-field appearance="outline">
-                  <textarea
-                    [disabled]="isReadOnly"
-                    matInput
-                    (focusin)="setHelpText(2, tooltip)"
-                    formControlName="reasonClaimingPartofTotalInvoice"
-                    style="resize: none"
-                    cdkTextareaAutosize
-                    #autosize="cdkTextareaAutosize"
-                    cdkAutosizeMinRows="2"
-                    cdkAutosizeMaxRows="5"
-                    maxlength="200"></textarea>
-                  <!--<mat-hint>{{ remainingLength }} characters remaining.</mat-hint>--> </mat-form-field
-                ><br />
-              </div>
+              <mat-radio-group
+                formControlName="isGoodsReceivedonInvoiceDate"
+                class="primary-radio-group horizontal-radio-group"
+                aria-label="Select an option">
+                <mat-radio-button value="true">Yes</mat-radio-button>&nbsp;&nbsp;<mat-radio-button value="false"
+                  >No</mat-radio-button
+                >
+
+                <mat-error
+                  *ngIf="
+                    invoiceForm.get('isGoodsReceivedonInvoiceDate').invalid &&
+                    invoiceForm.get('isGoodsReceivedonInvoiceDate').hasError('required')
+                  ">
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This is required
+                </mat-error>
+              </mat-radio-group>
+            </div>
+          </div>
+          <br />
+
+          <div
+            class="row"
+            [hidden]="(formCreationService.invoiceForm$ | async)?.value.isGoodsReceivedonInvoiceDate != 'false'">
+            <p style="font-size: 15px">
+              Select the date that the goods or services were received<span style="color: red">*</span>
+            </p>
+            <div class="col-md-6">
+              <mat-form-field appearance="outline">
+                <input
+                  matInput
+                  [matDatepicker]="goodsReceivedDatePicker"
+                  [readonly]="isReadOnly === true"
+                  formControlName="goodsReceivedDate" />
+                <mat-hint *ngIf="isReadOnly !== true">MM/DD/YYYY</mat-hint>
+                <mat-datepicker-toggle
+                  matSuffix
+                  [for]="goodsReceivedDatePicker"
+                  [disabled]="isReadOnly === true"></mat-datepicker-toggle>
+                <mat-datepicker #goodsReceivedDatePicker [disabled]="isReadOnly === true"></mat-datepicker>
+              </mat-form-field>
+            </div>
+          </div>
+          <br *ngIf="(formCreationService.invoiceForm$ | async)?.value.isGoodsReceivedonInvoiceDate == 'false'" />
+          <div class="row">
+            <p style="font-size: 15px">Purpose of goods or services received<span style="color: red">*</span></p>
+            <div class="col-md-12">
+              <mat-form-field appearance="outline">
+                <textarea
+                  [disabled]="isReadOnly"
+                  matInput
+                  formControlName="purposeOfGoodsServiceReceived"
+                  required
+                  style="resize: none"
+                  cdkTextareaAutosize
+                  #autosize="cdkTextareaAutosize"
+                  cdkAutosizeMinRows="2"
+                  cdkAutosizeMaxRows="5"
+                  maxlength="200"></textarea>
+                <!--<mat-hint>{{ remainingLength }} characters remaining.</mat-hint>-->
+              </mat-form-field>
+
+              <br />
             </div>
           </div>
 
-          <div class="col-md-6">
-            <div class="invoice-box">
-              <div class="row">
-                <div class="col-md-12 costCurrency">
-                  <p style="font-size: 15px; margin-bottom: 10px !important">
-                    Net invoiced being claimed (excluding taxes)<span style="color: red">*</span>
-                  </p>
-                  <mat-form-field appearance="outline" class="mat-form-round monetary-input">
-                    <div class="searchDiv">
-                      <input
-                        (focusin)="setHelpText(3, tooltip)"
-                        #currencyBoxnetInvoiceBeingClaimed
-                        id="currencyBoxnetInvoiceBeingClaimed"
-                        [formControl]="invoiceForm.controls['netInvoiceBeingClaimed']"
-                        matInput
-                        required
-                        mask="separator.2"
-                        thousandSeparator=","
-                        decimalMarker="."
-                        (keyup)="CalculateInvoice($event)"
-                        maxlength="100" />
-                      <span class="currencyText">CA$</span>
-                    </div>
-                  </mat-form-field>
-                </div>
-              </div>
-
-              <div class="row pst-box">
-                <div class="col-md-4 aln-txt">
-                  <p style="font-size: 15px">PST</p>
-                </div>
-                <div class="col-md-8 inputCurrency">
-                  $&nbsp;<mat-form-field
-                    class="monetary-input-small"
-                    appearance="outline"
-                    style="height: 30px !important">
-                    <input
-                      #PST
-                      (focusin)="setHelpText(4, tooltip)"
-                      [formControl]="invoiceForm.controls['pst']"
-                      matInput
-                      mask="separator.2"
-                      thousandSeparator=","
-                      decimalMarker="."
-                      (keyup)="CalculateInvoice($event)"
-                      maxlength="100" />
-                  </mat-form-field>
-                </div>
-                <div class="col-md-4 aln-txt">
-                  <p style="font-size: 15px">Gross GST</p>
-                </div>
-                <div class="col-md-8 inputCurrency">
-                  $&nbsp;<mat-form-field
-                    class="monetary-input-small"
-                    appearance="outline"
-                    style="height: 30px !important">
-                    <input
-                      #grossGST
-                      (focusin)="setHelpText(5, tooltip)"
-                      [formControl]="invoiceForm.controls['grossGST']"
-                      matInput
-                      mask="separator.2"
-                      thousandSeparator=","
-                      decimalMarker="."
-                      (keyup)="CalculateInvoice($event)"
-                      maxlength="100" />
-                  </mat-form-field>
-                </div>
-                <div class="col-md-7 aln-txt">
-                  <p style="font-size: 15px">
-                    <b>Actual Invoice Total</b>
-                  </p>
-                  <input
-                    #PST
-                    [formControl]="invoiceForm.controls['actualInvoiceTotal']"
-                    type="hidden"
-                    required
-                    maxlength="100" />
-                </div>
-                <div class="col-md-5">
-                  <p class="currency-invoice" style="padding-right: 22px; padding-top: 5px">
-                    <b>
-                      $&nbsp;{{
-                        (formCreationService.invoiceForm$ | async)?.value.actualInvoiceTotal | number: '1.2-2'
-                      }}
-                    </b>
-                  </p>
-                </div>
-              </div>
-
-              <div class="row pst-box">
-                <div class="col-md-7 aln-txt">
-                  <p style="font-size: 15px">PST</p>
-                </div>
-                <div class="col-md-5">
-                  <p class="currency-invoice" style="padding-right: 22px">
-                    $&nbsp;{{ (formCreationService.invoiceForm$ | async)?.value.pst | number: '1.2-2' }}
-                  </p>
-                </div>
-                <div class="col-md-4 aln-txt">
-                  <p style="font-size: 15px">Eligible GST</p>
-                </div>
-                <div class="col-md-8 inputCurrency">
-                  $&nbsp;<mat-form-field
-                    class="monetary-input-small"
-                    appearance="outline"
-                    style="height: 30px !important">
-                    <input
-                      (focusin)="setHelpText(6, tooltip)"
-                      #eligibleGST
-                      [formControl]="invoiceForm.controls['eligibleGST']"
-                      matInput
-                      mask="separator.2"
-                      thousandSeparator=","
-                      decimalMarker="."
-                      (keyup)="CalculateInvoice($event)"
-                      maxlength="100" />
-                  </mat-form-field>
-                </div>
-                <div class="col-md-7 aln-txt">
-                  <p style="font-size: 15px">
-                    <b>Total being Claimed</b>
-                  </p>
-                  <input
-                    (focusin)="setHelpText(7, tooltip)"
-                    #PST
-                    [formControl]="invoiceForm.controls['totalBeingClaimed']"
-                    type="hidden"
-                    required
-                    maxlength="100" />
-                </div>
-                <div class="col-md-5">
-                  <p class="currency-invoice" style="padding-right: 22px; padding-top: 5px">
-                    <b>
-                      $&nbsp;{{ (formCreationService.invoiceForm$ | async)?.value.totalBeingClaimed | number: '1.2-2' }}
-                    </b>
-                  </p>
-                </div>
-              </div>
+          <div class="row">
+            <div class="col-md-12">
+              <p style="font-size: 15px">
+                Are you claiming only a portion or part of the total invoice amount?<span style="color: red">*</span>
+              </p>
+              <mat-radio-group
+                formControlName="isClaimforPartofTotalInvoice"
+                class="primary-radio-group horizontal-radio-group"
+                (change)="selectDamageDates($event)"
+                aria-label="Select an option">
+                <mat-radio-button value="true">Yes</mat-radio-button>&nbsp;&nbsp;<mat-radio-button value="false"
+                  >No</mat-radio-button
+                >
+                <mat-error *ngIf="invoiceForm.get('isClaimforPartofTotalInvoice').hasError('required')">
+                  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp; This is required
+                </mat-error>
+              </mat-radio-group>
+            </div>
+          </div>
+          <br />
+          <div
+            class="row"
+            [hidden]="(formCreationService.invoiceForm$ | async)?.value.isClaimforPartofTotalInvoice != 'true'">
+            <p style="font-size: 15px">
+              Please state why you are claiming only a portion of the total invoice<span style="color: red">*</span>
+            </p>
+            <div class="col-md-12">
+              <mat-form-field appearance="outline">
+                <textarea
+                  [disabled]="isReadOnly"
+                  matInput
+                  (focusin)="setHelpText(2, tooltip)"
+                  formControlName="reasonClaimingPartofTotalInvoice"
+                  style="resize: none"
+                  cdkTextareaAutosize
+                  #autosize="cdkTextareaAutosize"
+                  cdkAutosizeMinRows="2"
+                  cdkAutosizeMaxRows="5"
+                  maxlength="200"></textarea>
+                <!--<mat-hint>{{ remainingLength }} characters remaining.</mat-hint>--> </mat-form-field
+              ><br />
             </div>
           </div>
         </div>
-      </ng-container>
-      <div class="row">
-        <div class="col-md-9"></div>
-        <div class="col-md-3 align-cancel-col">
-          <button class="button-s cancel" type="button" (click)="cancel()">Cancel</button>
-          <button *ngIf="isReadOnly != true" type="submit" class="button-p add-invoice" (click)="AddInvoice()">
-            {{ addeditInvoiceText }}
-          </button>
+
+        <div class="col-md-6">
+          <div class="invoice-box">
+            <div class="row">
+              <div class="col-md-12 costCurrency">
+                <p style="font-size: 15px; margin-bottom: 10px !important">
+                  Net invoiced being claimed (excluding taxes)<span style="color: red">*</span>
+                </p>
+                <mat-form-field appearance="outline" class="mat-form-round monetary-input">
+                  <div class="searchDiv">
+                    <input
+                      (focusin)="setHelpText(3, tooltip)"
+                      #currencyBoxnetInvoiceBeingClaimed
+                      id="currencyBoxnetInvoiceBeingClaimed"
+                      [formControl]="invoiceForm.controls['netInvoiceBeingClaimed']"
+                      matInput
+                      required
+                      mask="separator.2"
+                      thousandSeparator=","
+                      decimalMarker="."
+                      (keyup)="CalculateInvoice($event)"
+                      maxlength="100" />
+                    <span class="currencyText">CA$</span>
+                  </div>
+                </mat-form-field>
+              </div>
+            </div>
+
+            <div class="row pst-box">
+              <div class="col-md-4 aln-txt">
+                <p style="font-size: 15px">PST</p>
+              </div>
+              <div class="col-md-8 inputCurrency">
+                $&nbsp;<mat-form-field
+                  class="monetary-input-small"
+                  appearance="outline"
+                  style="height: 30px !important">
+                  <input
+                    #PST
+                    (focusin)="setHelpText(4, tooltip)"
+                    [formControl]="invoiceForm.controls['pst']"
+                    matInput
+                    mask="separator.2"
+                    thousandSeparator=","
+                    decimalMarker="."
+                    (keyup)="CalculateInvoice($event)"
+                    maxlength="100" />
+                </mat-form-field>
+              </div>
+              <div class="col-md-4 aln-txt">
+                <p style="font-size: 15px">Gross GST</p>
+              </div>
+              <div class="col-md-8 inputCurrency">
+                $&nbsp;<mat-form-field
+                  class="monetary-input-small"
+                  appearance="outline"
+                  style="height: 30px !important">
+                  <input
+                    #grossGST
+                    (focusin)="setHelpText(5, tooltip)"
+                    [formControl]="invoiceForm.controls['grossGST']"
+                    matInput
+                    mask="separator.2"
+                    thousandSeparator=","
+                    decimalMarker="."
+                    (keyup)="CalculateInvoice($event)"
+                    maxlength="100" />
+                </mat-form-field>
+              </div>
+              <div class="col-md-7 aln-txt">
+                <p style="font-size: 15px">
+                  <b>Actual Invoice Total</b>
+                </p>
+                <input
+                  #PST
+                  [formControl]="invoiceForm.controls['actualInvoiceTotal']"
+                  type="hidden"
+                  required
+                  maxlength="100" />
+              </div>
+              <div class="col-md-5">
+                <p class="currency-invoice" style="padding-right: 22px; padding-top: 5px">
+                  <b>
+                    $&nbsp;{{ (formCreationService.invoiceForm$ | async)?.value.actualInvoiceTotal | number: '1.2-2' }}
+                  </b>
+                </p>
+              </div>
+            </div>
+
+            <div class="row pst-box">
+              <div class="col-md-7 aln-txt">
+                <p style="font-size: 15px">PST</p>
+              </div>
+              <div class="col-md-5">
+                <p class="currency-invoice" style="padding-right: 22px">
+                  $&nbsp;{{ (formCreationService.invoiceForm$ | async)?.value.pst | number: '1.2-2' }}
+                </p>
+              </div>
+              <div class="col-md-4 aln-txt">
+                <p style="font-size: 15px">Eligible GST</p>
+              </div>
+              <div class="col-md-8 inputCurrency">
+                $&nbsp;<mat-form-field
+                  class="monetary-input-small"
+                  appearance="outline"
+                  style="height: 30px !important">
+                  <input
+                    (focusin)="setHelpText(6, tooltip)"
+                    #eligibleGST
+                    [formControl]="invoiceForm.controls['eligibleGST']"
+                    matInput
+                    mask="separator.2"
+                    thousandSeparator=","
+                    decimalMarker="."
+                    (keyup)="CalculateInvoice($event)"
+                    maxlength="100" />
+                </mat-form-field>
+              </div>
+              <div class="col-md-7 aln-txt">
+                <p style="font-size: 15px">
+                  <b>Total being Claimed</b>
+                </p>
+                <input
+                  (focusin)="setHelpText(7, tooltip)"
+                  #PST
+                  [formControl]="invoiceForm.controls['totalBeingClaimed']"
+                  type="hidden"
+                  required
+                  maxlength="100" />
+              </div>
+              <div class="col-md-5">
+                <p class="currency-invoice" style="padding-right: 22px; padding-top: 5px">
+                  <b>
+                    $&nbsp;{{ (formCreationService.invoiceForm$ | async)?.value.totalBeingClaimed | number: '1.2-2' }}
+                  </b>
+                </p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </form>
   </mat-card-content>
+
+  <mat-card-actions class="card-actions-container">
+    <div class="row w-100">
+      <div class="d-flex justify-content-end p-0 w-100">
+        <button class="button-s cancel" type="button" (click)="cancel()">Cancel</button>
+        <button *ngIf="isReadOnly != true" type="submit" class="button-p add-invoice" (click)="AddInvoice()">
+          {{ addeditInvoiceText }}
+        </button>
+      </div>
+    </div>
+  </mat-card-actions>
 </mat-card>

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/invoice/invoice.component.scss
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-claim-main-forms/invoice/invoice.component.scss
@@ -1,18 +1,32 @@
+.card-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  border: none;
+}
+
+.card-header-container {
+  padding: 1rem 1.25rem 0 1.25rem;
+  margin-bottom: 1rem;
+}
+
+.card-content-container {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 0.25rem 1.25rem;
+}
+
+.card-actions-container {
+  padding: 0 1.25rem 1rem 1.25rem;
+  margin-top: 1rem;
+}
+
 mat-form-field {
   width: 100%;
 }
 
-.header-align-inv {
-  margin-bottom: 20px !important;
-}
-
 .hr-align {
   border: 1px solid gray;
-}
-
-.align-cancel-col {
-  display: flex;
-  justify-content: flex-end;
 }
 
 .recoveryPlan p {
@@ -91,6 +105,7 @@ mat-form-field {
   border-left: 1px solid black;
 }
 
+
 ::ng-deep .costCurrency .mat-mdc-form-field-infix {
   padding: 9px !important;
 }
@@ -100,11 +115,6 @@ mat-form-field {
   background-color: white;
 }
 
-/*
-::ng-deep .costCurrency .mat-form-field-infix {
-  border-right: 50px solid transparent;
-}*/
-
 ::ng-deep .pst-box .mat-mdc-form-field-infix {
   /*border-top: 6px solid transparent;*/
   padding: 5px !important;
@@ -113,10 +123,6 @@ mat-form-field {
 ::ng-deep .pst-box .mat-form-field-appearance-outline {
   border-radius: 6px;
   background-color: white;
-}
-
-::ng-deep .mat-mdc-card-content {
-  padding: 30px !important;
 }
 
 ::ng-deep .mat-mdc-form-field-error {


### PR DESCRIPTION
## Ticket

https://emcr.atlassian.net/browse/D4P-226

## Changes

Update the HTML/SCSS of the Claim Invoice dialog component.
- Sets the header and button bar of the modal window to not scroll (only the content scrolls), so the cancel/save buttons are never hidden.

## Notes

Contain no functional/data changes, just styling.