### PR TITLE
D4P-112: Tweak ConfigurationController FeartureFlag Logic

### DIFF
--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/ConfigurationController.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Controllers/ConfigurationController.cs
@@ -95,10 +95,10 @@ namespace EMBC.DFA.API.Controllers
                 },
                 FeatureFlags = new FeatureFlagConfiguration
                 {
-                    UseAppeals = !string.IsNullOrEmpty(configuration["FEATURE_USE_APPEALS"]),
-                    UseAmendments = !string.IsNullOrEmpty(configuration["FEATURE_USE_AMENDMENTS"]),
-                    UseAdvancedPayments = !string.IsNullOrEmpty(configuration["FEATURE_USE_ADVANCED_PAYMENTS"]),
-                    UseAutoNotifications = !string.IsNullOrEmpty(configuration["FEATURE_USE_AUTO_NOTIFICATIONS"])
+                    UseAppeals = configuration.GetValue<bool>("FEATURE_USE_APPEALS"),
+                    UseAmendments = configuration.GetValue<bool>("FEATURE_USE_AMENDMENTS"),
+                    UseAdvancedPayments = configuration.GetValue<bool>("FEATURE_USE_ADVANCED_PAYMENTS"),
+                    UseAutoNotifications = configuration.GetValue<bool>("FEATURE_USE_AUTO_NOTIFICATIONS")
                 }
 
             };

--- a/dfa/src/API/EMBC.DFA.API/Controllers/ConfigurationController.cs
+++ b/dfa/src/API/EMBC.DFA.API/Controllers/ConfigurationController.cs
@@ -94,8 +94,8 @@ namespace EMBC.DFA.API.Controllers
                 },
                 FeatureFlags = new FeatureFlagConfiguration
                 {
-                    UseAppeals = !string.IsNullOrEmpty(configuration["FEATURE_USE_APPEALS"]),
-                    UseAutoNotifications = !string.IsNullOrEmpty(configuration["FEATURE_USE_AUTO_NOTIFICATIONS"])
+                    UseAppeals = configuration.GetValue<bool>("FEATURE_USE_APPEALS"),
+                    UseAutoNotifications = configuration.GetValue<bool>("FEATURE_USE_AUTO_NOTIFICATIONS")
                 }
             };
 


### PR DESCRIPTION
## Ticket

https://emcr.atlassian.net/browse/D4P-112

## Changes
Minor update to the `ConfigurationController.cs` logic for the feature flags.
- Previously it treated the feature flags as `true` if they had any non-null value, and `false` otherwise. 
- Now, they specifically enable if the value is (`true`, `"true"`), and are disabled if the value is (`false`, `"false"`). This also aligns with how the existing S3 feature flag works.

## Note

Does not require any changes to the existing openshift environment variables.