### PR TITLE
D4P-TechDebt-3: DateTime Fix

### DIFF
--- a/dfa/src/API/EMBC.DFA.API/Program.cs
+++ b/dfa/src/API/EMBC.DFA.API/Program.cs
@@ -1,5 +1,11 @@
 ﻿using System;
+using System.Globalization;
 using EMBC.Utilities.Hosting;
+
+// Set culture to ensure datetime parsing is consistent across different environments.
+// Set to "en-US" to align with the format used in the dynamics responses, and hardcoded throughout the api/app.
+CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-US");
+CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("en-US");
 
 var appName = Environment.GetEnvironmentVariable("APP_NAME") ?? "EMBC.DFA.API";
 

--- a/dfa/src/API/EMBC.Utilities.Hosting/Logging.cs
+++ b/dfa/src/API/EMBC.Utilities.Hosting/Logging.cs
@@ -16,7 +16,7 @@ namespace EMBC.Utilities.Hosting
 {
     internal static class Logging
     {
-        public const string LogOutputTemplate = "[{Timestamp:HH:mm:ss} {Level:u3} {SourceContext}] {Message:lj}{NewLine}{Exception}";
+        public const string LogOutputTemplate = "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3} {SourceContext}] {Message:lj}{NewLine}{Exception}";
 
         public static void ConfigureSerilog(HostBuilderContext hostBuilderContext, IServiceProvider services, LoggerConfiguration loggerConfiguration, string appName)
         {

--- a/dfa/src/UI/embc-dfa/src/app/core/api/models/feature-flag-configuration.ts
+++ b/dfa/src/UI/embc-dfa/src/app/core/api/models/feature-flag-configuration.ts
@@ -4,4 +4,5 @@
 
 export interface FeatureFlagConfiguration {
   useAppeals?: boolean;
+  useAutoNotifications?: boolean;
 }


### PR DESCRIPTION
## Changes
### DFA Private
Fix inconsistent culture, causing environment dependent datetime parsing errors.
- The app is built to expect US Format MM/DD/YYYY but the dotnet was defaulting to the host datetime format, which would cause exceptions if it didn't match the US Format.

Update logger to include the date alongside the time.
- Previously the log output only included the time, which makes it difficult to debug issues as you can't tell if a log message was from today or a week ago.

## Notes
Both of these changes were added to dfa-public a few weeks ago, for the same reasons (https://github.com/bcgov/emcr-dfa-portal/pull/850)