### PR TITLE
DEVOPS-443 add public API auth for calling pdf service

### DIFF
--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Configuration.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Configuration.cs
@@ -283,7 +283,9 @@ namespace EMBC.DFA.API
             services.AddTransient<IDynamicsGateway, DynamicsGateway>();
 
             services.Configure<PdfServiceConfigs>(configuration.GetSection("pdfService"));
-            services.AddTransient<PDFServiceHandler, PDFServiceHandler>();
+            services.AddTransient<TokenDelegatingHandler>();
+            services.AddHttpClient<PDFServiceHandler>()
+                .AddHttpMessageHandler<TokenDelegatingHandler>();
             services.AddTransient<BearerTokenProvider>();
 
             // 2024-07-02 EMCRI-363 waynezen: added

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Configuration.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Configuration.cs
@@ -28,7 +28,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.Net.Http.Headers;
@@ -38,6 +37,7 @@ using NSwag.Generation.Processors.Security;
 using Xrm.Tools.WebAPI;
 using Xrm.Tools.WebAPI.Requests;
 using ITokenProvider = EMBC.DFA.API.Services.ITokenProvider;
+using EMBC.DFA.PUBLIC.API.Services;
 
 namespace EMBC.DFA.API
 {
@@ -281,17 +281,17 @@ namespace EMBC.DFA.API
             services.AddTransient<IProfileInviteService, ProfileInviteService>();
             services.AddTransient<IConfigurationHandler, Handler>();
             services.AddTransient<IDynamicsGateway, DynamicsGateway>();
+
+            services.Configure<PdfServiceConfigs>(configuration.GetSection("pdfService"));
             services.AddTransient<PDFServiceHandler, PDFServiceHandler>();
+            services.AddTransient<BearerTokenProvider>();
 
-            
-
-                // 2024-07-02 EMCRI-363 waynezen: added
+            // 2024-07-02 EMCRI-363 waynezen: added
             services.AddTransient<IUserService, UserService>();
 
             services.Configure<ADFSTokenProviderOptions>(configuration.GetSection("Dynamics:ADFS"));
-            services.Configure<PdfServiceConfigs>(configuration.GetSection("pdfService"));
-
             services.AddADFSTokenProvider();
+
             services.AddHttpClient("captcha");
             services.AddScoped(sp =>
             {

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/PDF/PDFService/PDFServiceHandler.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/PDF/PDFService/PDFServiceHandler.cs
@@ -13,35 +13,35 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.PDF.PDFService
     public class PDFServiceHandler
     {
         private PdfServiceConfigs options;
+        private readonly HttpClient _httpClient;
 
-        public PDFServiceHandler(IOptions<PdfServiceConfigs> options, BearerTokenProvider bearerTokenProvider)
+        public PDFServiceHandler(HttpClient httpClient, IOptions<PdfServiceConfigs> options, BearerTokenProvider bearerTokenProvider)
         {
             this.options = options.Value;
+
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            _httpClient = httpClient;
         }
 
-        public async Task<byte[]> GetFileDataAsync(PdfReuest pdfReuest)
+        public async Task<byte[]> GetFileDataAsync(PdfReuest pdfRequest)
         {
             byte[] fileBytes = null;
             var url = options.GeneratePDFFile;
-            using (HttpClient client = new HttpClient())
+
+            try
             {
-                try
-                {
-                    client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                    var bearerToken = await new BearerTokenProvider(client, Options.Create(options), null).GetAccessTokenAsync();
-                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
-                    var content = new StringContent(JsonConvert.SerializeObject(pdfReuest), Encoding.UTF8, "application/json");
-                    var response = await client.PostAsync(options.GeneratePDFFile, content);
-                    response.EnsureSuccessStatusCode();
-                    fileBytes = await response.Content.ReadAsByteArrayAsync();
-                    //await File.WriteAllBytesAsync(downloadPath, fileBytes);
-                    Console.WriteLine("File downloaded successfully.");
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"An error occurred: {ex.Message}");
-                }
+                var content = new StringContent(JsonConvert.SerializeObject(pdfRequest), Encoding.UTF8, "application/json");
+                var response = await _httpClient.PostAsync(options.GeneratePDFFile, content);
+                response.EnsureSuccessStatusCode();
+                fileBytes = await response.Content.ReadAsByteArrayAsync();
+                //await File.WriteAllBytesAsync(downloadPath, fileBytes);
+                Console.WriteLine("File downloaded successfully.");
             }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"An error occurred: {ex.Message}");
+            }
+            
             return fileBytes;
         }
     }

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/PDF/PDFService/PDFServiceHandler.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/PDF/PDFService/PDFServiceHandler.cs
@@ -3,10 +3,8 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using EMBC.DFA.API.ConfigurationModule.Models.Dynamics;
 using EMBC.DFA.API.Services;
-using EMBC.Utilities.Configuration;
-using Microsoft.Extensions.Configuration;
+using EMBC.DFA.PUBLIC.API.Services;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
@@ -16,10 +14,11 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.PDF.PDFService
     {
         private PdfServiceConfigs options;
 
-        public PDFServiceHandler(IOptions<PdfServiceConfigs> options)
+        public PDFServiceHandler(IOptions<PdfServiceConfigs> options, BearerTokenProvider bearerTokenProvider)
         {
             this.options = options.Value;
         }
+
         public async Task<byte[]> GetFileDataAsync(PdfReuest pdfReuest)
         {
             byte[] fileBytes = null;
@@ -29,14 +28,12 @@ namespace EMBC.DFA.API.ConfigurationModule.Models.PDF.PDFService
                 try
                 {
                     client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                    var bearerToken = await new BearerTokenProvider(client, Options.Create(options), null).GetAccessTokenAsync();
+                    client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
                     var content = new StringContent(JsonConvert.SerializeObject(pdfReuest), Encoding.UTF8, "application/json");
-                    // Send the POST request
-                    HttpResponseMessage response = await client.PostAsync(options.GeneratePDFFile, content);
-                    // Ensure the request was successful
+                    var response = await client.PostAsync(options.GeneratePDFFile, content);
                     response.EnsureSuccessStatusCode();
-                    // Read the content as a byte array
                     fileBytes = await response.Content.ReadAsByteArrayAsync();
-                    // Save the file to the specified location
                     //await File.WriteAllBytesAsync(downloadPath, fileBytes);
                     Console.WriteLine("File downloaded successfully.");
                 }

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/PDF/PDFService/PDFServiceHandler.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/ConfigurationModule/Models/PDF/PDFService/PDFServiceHandler.cs
@@ -3,13 +3,20 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
-using EMBC.DFA.API.Services;
 using EMBC.DFA.PUBLIC.API.Services;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 
 namespace EMBC.DFA.API.ConfigurationModule.Models.PDF.PDFService
 {
+    public class PdfServiceConfigs
+    {
+        public string GeneratePDFFile { get; set; }
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+        public string TokenUrl { get; set; }
+    }
+
     public class PDFServiceHandler
     {
         private PdfServiceConfigs options;

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/EMBC.DFA.PUBLIC.API.csproj
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/EMBC.DFA.PUBLIC.API.csproj
@@ -39,9 +39,9 @@
     <ItemGroup>
         <PackageReference Include="IdentityModel.AspNetCore.OAuth2Introspection" Version="6.2.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.13" />
-
         <PackageReference Include="NSwag.AspNetCore" Version="14.2.0" />
-
+        <PackageReference Include="Polly" Version="8.6.1" />
+        <PackageReference Include="Polly.Contrib.WaitAndRetry" Version="1.1.1" />
         <PackageReference Include="System.ServiceModel.Http" Version="8.1.2" />
         <PackageReference Include="System.ServiceModel.Security" Version="6.0.0" />
         <PackageReference Include="Xrm.Tools.CRMWebAPI" Version="1.0.25" />

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/ADFSTokenProvider.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/ADFSTokenProvider.cs
@@ -79,14 +79,6 @@ namespace EMBC.DFA.API.Services
         public string ResourceName { get; set; }
     }
 
-    public class PdfServiceConfigs
-    {
-        public string GeneratePDFFile { get; set; }
-        public string ClientId { get; set; }
-        public string ClientSecret { get; set; }
-        public string TokenUrl { get; set; }
-    }
-
     public static class AccessTokenProviderEx
     {
         public static IServiceCollection AddADFSTokenProvider(this IServiceCollection services)

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/ADFSTokenProvider.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/ADFSTokenProvider.cs
@@ -78,10 +78,15 @@ namespace EMBC.DFA.API.Services
         public string ServiceAccountPassword { get; set; }
         public string ResourceName { get; set; }
     }
+
     public class PdfServiceConfigs
     {
         public string GeneratePDFFile { get; set; }
+        public string ClientId { get; set; }
+        public string ClientSecret { get; set; }
+        public string TokenUrl { get; set; }
     }
+
     public static class AccessTokenProviderEx
     {
         public static IServiceCollection AddADFSTokenProvider(this IServiceCollection services)

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/BearerTokenProvider.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/BearerTokenProvider.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading.Tasks;
+using EMBC.Database.Shared.Contract;
+using EMBC.DFA.API.Services;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json.Linq;
+
+namespace EMBC.DFA.PUBLIC.API.Services;
+
+public class BearerTokenProvider(HttpClient httpClient, IOptions<PdfServiceConfigs> options, ILogger<BearerTokenProvider> logger)
+{
+    private string _bearerToken;
+    private readonly PdfServiceConfigs options = options.Value;
+
+    public async Task<string> GetAccessTokenAsync()
+    {
+        // Add Policy to retrieve token if existing token returns 401 Unauthorized, see CAS Adapter solution for an example
+        //if (_bearerToken == null)
+            await RefreshTokenAsync();
+        return _bearerToken;
+    }
+
+    public async Task RefreshTokenAsync()
+    {
+        options?.ClientId.ThrowIfNullOrEmpty();
+        options.ClientSecret.ThrowIfNullOrEmpty();
+        options.TokenUrl.ThrowIfNullOrEmpty();
+
+        try
+        {
+            var base64 = Convert.ToBase64String(System.Text.ASCIIEncoding.ASCII.GetBytes(string.Format("{0}:{1}", options.ClientId, options.ClientSecret)));
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", base64);
+            var request = new HttpRequestMessage(HttpMethod.Post, options.TokenUrl);
+            var formData = new List<KeyValuePair<string, string>>();
+            formData.Add(new KeyValuePair<string, string>("grant_type", "client_credentials"));
+            request.Content = new FormUrlEncodedContent(formData);
+            var response = await httpClient.SendAsync(request);
+            response.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+            if (!response.IsSuccessStatusCode)
+            {
+                logger.LogError($"Error getting token: {response.StatusCode} - {response.Content}");
+                throw new Exception("Unable to refresh token.");
+            }
+            string responseBody = await response.Content.ReadAsStringAsync();
+            var jo = JObject.Parse(responseBody);
+            _bearerToken = jo["access_token"].ToString();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError($"TokenProvider.RefreshTokenAsync failed: {ex.ToString()}");
+            throw;
+        }
+    }
+}

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/BearerTokenProvider.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/BearerTokenProvider.cs
@@ -4,7 +4,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using EMBC.Database.Shared.Contract;
-using EMBC.DFA.API.Services;
+using EMBC.DFA.API.ConfigurationModule.Models.PDF.PDFService;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json.Linq;

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/BearerTokenProvider.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/BearerTokenProvider.cs
@@ -18,8 +18,7 @@ public class BearerTokenProvider(HttpClient httpClient, IOptions<PdfServiceConfi
 
     public async Task<string> GetAccessTokenAsync()
     {
-        // Add Policy to retrieve token if existing token returns 401 Unauthorized, see CAS Adapter solution for an example
-        //if (_bearerToken == null)
+        if (_bearerToken == null)
             await RefreshTokenAsync();
         return _bearerToken;
     }

--- a/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/TokenDelegatingHandler.cs
+++ b/dfa-public/src/API/EMBC.DFA.PUBLIC.API/Services/TokenDelegatingHandler.cs
@@ -1,0 +1,23 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Polly;
+using Polly.Retry;
+
+namespace EMBC.DFA.PUBLIC.API.Services;
+
+public class TokenDelegatingHandler(BearerTokenProvider tokenProvider) : DelegatingHandler
+{
+    private readonly AsyncRetryPolicy<HttpResponseMessage> _policy = Policy
+        .HandleResult<HttpResponseMessage>(r => r.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden)
+        .RetryAsync((_, _) => tokenProvider.RefreshTokenAsync());
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        => await _policy.ExecuteAsync(async () =>
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", await tokenProvider.GetAccessTokenAsync());
+            return await base.SendAsync(request, cancellationToken);
+        });
+}


### PR DESCRIPTION
The following secrets were added:

```
    "tokenUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/token",
    "clientId": "dfa-pdf-service-6036",
    "clientSecret": "********"
```
to "pdfService", which will look like:

```
  "pdfService": {
    "generatePDFFile": "https://dfa-public-sector-pdf-dev.apps.silver.devops.gov.bc.ca/api/PDF/GetPDF",
    "tokenUrl": "https://dev.loginproxy.gov.bc.ca/auth/realms/standard/protocol/openid-connect/token",
    "clientId": "dfa-pdf-service-6036",
    "clientSecret": "********"
  },
```
