### PR TITLE
hotfix/ SecondarySignature required

### DIFF
--- a/dfa/src/UI/embc-dfa/src/app/core/components/signature/signature.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/core/components/signature/signature.component.ts
@@ -80,11 +80,24 @@ export class SignatureComponent implements AfterViewInit, OnChanges {
     }
   }
 
+  private isCanvasBlank(canvas: HTMLCanvasElement): boolean {
+    const context = canvas.getContext('2d');
+    const pixelBuffer = new Uint32Array(
+      context.getImageData(0, 0, canvas.width, canvas.height).data.buffer
+    );
+    return !pixelBuffer.some(color => color !== 0);
+  }
+
   // store in signature block to emit
   updateCanvas() {
     const canvasEl: HTMLCanvasElement = this.canvas.nativeElement;
-    this.signatureBlock.signature = canvasEl.toDataURL();
-    this.signatureFormGroup.get('signature')?.setValue(this.signatureBlock.signature);
+    if (this.isCanvasBlank(canvasEl)) {
+      this.signatureBlock.signature = null;
+      this.signatureFormGroup.get('signature')?.setValue(null);
+    } else {
+      this.signatureBlock.signature = canvasEl.toDataURL();
+      this.signatureFormGroup.get('signature')?.setValue(this.signatureBlock.signature);
+    }
     this.updateSignatureBlock();
   }
 


### PR DESCRIPTION
- Secondary signature is required because the signature field is not null, the value is a blank signature.
- Assigning null instead of string base64 of blank signature.

