### PR TITLE
D4P-25: Modal window for Appeal Cancelation to match appeal public flow

### DIFF
--- a/dfa/src/UI/embc-dfa/src/app/core/components/dialog-components/dfa-cancel-confirmation-dialog/dfa-cancel-confirmation-dialog.component.html
+++ b/dfa/src/UI/embc-dfa/src/app/core/components/dialog-components/dfa-cancel-confirmation-dialog/dfa-cancel-confirmation-dialog.component.html
@@ -1,0 +1,32 @@
+<!-- Title + Close Icon Button in a flex row -->
+<div class="dialog-header">
+  <h2 mat-dialog-title style="margin: 0;">{{ data.title }}</h2>
+  <button
+    *ngIf="data.showCloseIcon"
+    mat-icon-button
+    class="dialog-close-button"
+    aria-label="Close dialog"
+    (click)="onCancel()"
+  >
+    <mat-icon class="dialog-close-icon">close</mat-icon>
+  </button>
+</div>
+
+<!-- Divider BELOW the title bar -->
+<mat-divider class="dialog-divider"></mat-divider>
+
+<!-- Content -->
+<mat-dialog-content>
+  <p *ngIf="data.subtitle"><strong>{{ data.subtitle }}</strong></p>
+  <p class="dialog-text">{{ data.text }}</p>
+</mat-dialog-content>
+
+<!-- Actions -->
+<mat-dialog-actions align="end" class="dialog-actions">
+  <button mat-button (click)="onCancel()" class="cancel-button">
+    {{ data.cancelButton || 'Cancel' }}
+  </button>
+  <button mat-raised-button color="primary" (click)="onConfirm()">
+    {{ data.confirmButton || 'Confirm' }}
+  </button>
+</mat-dialog-actions>

--- a/dfa/src/UI/embc-dfa/src/app/core/components/dialog-components/dfa-cancel-confirmation-dialog/dfa-cancel-confirmation-dialog.component.scss
+++ b/dfa/src/UI/embc-dfa/src/app/core/components/dialog-components/dfa-cancel-confirmation-dialog/dfa-cancel-confirmation-dialog.component.scss
@@ -1,0 +1,44 @@
+.dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-right: 4px;
+  margin-right: 8px;
+  overflow: hidden;
+}
+
+.dialog-close-button {
+  width: 24px;
+  height: 24px;
+  min-width: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dialog-close-icon {
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  line-height: 1;
+}
+
+.dialog-divider {
+  border-top-color: #234075;
+}
+
+.dialog-actions {
+  gap: 20px;
+}
+
+.cancel-button {
+  border: 1px solid #003366 !important;
+  color: #036 !important;
+  background-color: transparent;
+  border-radius: 4px;
+}
+
+.dialog-text {
+  white-space: pre-line;
+}

--- a/dfa/src/UI/embc-dfa/src/app/core/components/dialog-components/dfa-cancel-confirmation-dialog/dfa-cancel-confirmation-dialog.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/core/components/dialog-components/dfa-cancel-confirmation-dialog/dfa-cancel-confirmation-dialog.component.ts
@@ -1,0 +1,29 @@
+import { CommonModule } from '@angular/common';
+import { Component, Inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatIconModule } from '@angular/material/icon';
+import { DialogContent } from 'src/app/core/model/dialog-content.model';
+
+@Component({
+  standalone: true,
+  selector: 'app-cancel-confirmation-dialog',
+  templateUrl: './dfa-cancel-confirmation-dialog.component.html',
+  styleUrls: ['./dfa-cancel-confirmation-dialog.component.scss'],
+  imports: [CommonModule, MatDialogModule, MatButtonModule, MatIconModule, MatDividerModule ]
+})
+export class CancelConfirmationDialogComponent {
+  constructor(
+    public dialogRef: MatDialogRef<CancelConfirmationDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: DialogContent
+  ) {}
+
+  onCancel(): void {
+    this.dialogRef.close(false);
+  }
+
+  onConfirm(): void {
+    this.dialogRef.close(true);
+  }
+}

--- a/dfa/src/UI/embc-dfa/src/app/core/model/dialog-content.model.ts
+++ b/dfa/src/UI/embc-dfa/src/app/core/model/dialog-content.model.ts
@@ -5,4 +5,5 @@ export interface DialogContent {
   confirmButton?: null | string;
   cancelButton?: null | string;
   exitLink?: null | string;
+  showCloseIcon?: boolean;
 }

--- a/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-appeal/dfa-appeal.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-appeal/dfa-appeal.component.ts
@@ -1,6 +1,7 @@
 import { ChangeDetectorRef, Component, OnInit, ViewChild } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { MatStepper } from '@angular/material/stepper';
+import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
 import {
@@ -14,6 +15,7 @@ import { FormCreationService } from '../../core/services/formCreation.service';
 import { DFAAppealDataService } from './dfa-appeal-data.service';
 import { DfaAppealService } from './dfa-appeal.service';
 import { AppealType } from 'src/app/core/model/dfa-appeals-main.model';
+import { CancelConfirmationDialogComponent } from 'src/app/core/components/dialog-components/dfa-cancel-confirmation-dialog/dfa-cancel-confirmation-dialog.component';
 
 @Component({
   selector: 'app-dfa-appeal',
@@ -53,7 +55,8 @@ export class DfaAppealComponent implements OnInit {
     private cd: ChangeDetectorRef,
     private dfaAppealDataService: DFAAppealDataService,
     private dfaAppealService: DfaAppealService,
-    private applicationService: ApplicationService
+    private applicationService: ApplicationService,
+    public dialog: MatDialog
   ) {}
 
   ngOnInit(): void {
@@ -130,10 +133,48 @@ export class DfaAppealComponent implements OnInit {
    */
   goBack(stepper: MatStepper, lastStep: number): void {
     if (lastStep === -2) {
-      this.returnToDashboard();
+      this.showCancelAppealDialog();
     } else {
       stepper.selectedIndex = lastStep;
     }
+  }
+
+  /**
+   * Shows the cancel appeal confirmation dialog
+   */
+  showCancelAppealDialog(): void {
+    const dialogRef = this.dialog.open(CancelConfirmationDialogComponent, {
+      data: {
+        title: 'Cancel Appeal',
+        subtitle: 'Are you sure you want to cancel your appeal?',
+        text: "Appeals must be created and submitted in the same session.\nDrafts are not saved - any changes you've made will be lost.",
+        cancelButton: 'No, go back',
+        confirmButton: 'Yes, cancel appeal',
+        showCloseIcon: true
+      },
+      width: '500px',
+      disableClose: true
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result === true) {
+        this.cancelAppeal();
+      }
+    });
+  }
+
+  /**
+   * Cancels the appeal and navigates back to dashboard
+   */
+  private cancelAppeal(): void {
+    // Clear any form data
+    this.dfaAppealDataService.appealReason = null;
+    this.dfaAppealDataService.signAndSubmit = null;
+    this.formCreationService.clearAppealReasonData();
+    this.formCreationService.clearAppealSignAndSubmitData();
+
+    // Navigate back to dashboard
+    this.returnToDashboard();
   }
 
   /**
@@ -227,7 +268,7 @@ export class DfaAppealComponent implements OnInit {
     if (this.form$) {
       this.form$.unsubscribe();
     }
-    
+
     switch (index) {
       case 0:
         this.form$ = this.formCreationService
@@ -258,7 +299,7 @@ export class DfaAppealComponent implements OnInit {
   submitAppeal(): void {
     this.isLoading = true;
     this.setFormData('sign-and-submit');
-    
+
     let appeal = this.dfaAppealDataService.createAppealDTO();
     this.dfaAppealService.insertAppeal(appeal).subscribe({
       next: () => {

--- a/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-appeal/dfa-appeal.module.ts
+++ b/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-appeal/dfa-appeal.module.ts
@@ -2,22 +2,30 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatStepperModule } from '@angular/material/stepper';
+import { MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
 import { ComponentWrapperModule } from '../../sharedModules/components/component-wrapper/component-wrapper.module';
 import { DfaAppealFormsModule } from '../../sharedModules/forms/dfa-appeal-forms/dfa-appeal-forms.module';
 import { DfaAppealRoutingModule } from './dfa-appeal-routing.module';
 import { DfaAppealComponent } from './dfa-appeal.component';
+import { CancelConfirmationDialogComponent } from 'src/app/core/components/dialog-components/dfa-cancel-confirmation-dialog/dfa-cancel-confirmation-dialog.component';
 
 @NgModule({
   declarations: [
-    DfaAppealComponent
+    DfaAppealComponent,
   ],
   imports: [
     CommonModule,
     ReactiveFormsModule,
     MatStepperModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatIconModule,
     DfaAppealFormsModule,
     DfaAppealRoutingModule,
-    ComponentWrapperModule
+    ComponentWrapperModule,
+    CancelConfirmationDialogComponent
   ],
   exports: [
     DfaAppealComponent


### PR DESCRIPTION
Add modal window when user clicks on "Cancel Appeal" button:

![image](https://github.com/user-attachments/assets/eec5e762-8cd2-477c-b378-7bb88ad4344b)


[Story](https://emcr.atlassian.net/browse/D4P-25)