### PR TITLE
D4P # 368 Duplicate Document Upload Shows Error but Fails to Clear Previous Upload Data

### DIFF
--- a/dfa/src/UI/embc-dfa/src/app/core/components/dfa-attachment/dfa-attachment.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/core/components/dfa-attachment/dfa-attachment.component.ts
@@ -66,20 +66,9 @@ export class DfaAttachmentComponent implements OnInit, OnDestroy {
   }
 
   initFileUploadForm() {
-    let fileUploads = this.formCreationService.fileUploadsForm.value.get('fileUploads').value;
-    if (this.requiredDocumentType && fileUploads?.filter(x => x.requiredDocumentType === this.requiredDocumentType).length > 0) {
-      let foundIndex = fileUploads.findIndex(x => x.requiredDocumentType === this.requiredDocumentType);
-      this.fileUpload.setValue(fileUploads[foundIndex]);
-    } else {
-      this.fileUpload.reset();
-      this.fileUpload.get('modifiedBy').setValue("Applicant");
-      if (this.fileType) this.fileUpload.get('fileType').setValue(this.fileType); else this.fileUpload.get('fileType').setValue(null);
-      if (this.requiredDocumentType) this.fileUpload.get('requiredDocumentType').setValue(this.requiredDocumentType); else this.fileUpload.get('requiredDocumentType').setValue(null);
-      this.fileUpload.get('deleteFlag').setValue(false);
-      this.fileUpload.get('applicationId').setValue(this.dfaApplicationMainDataService.getApplicationId());
-      this.fileUpload.get('id').setValue(null);
-      this.fileUpload.updateValueAndValidity();
-    }
+    this.fileUpload.reset();
+    this.updateFileUploadFormOnVisibility();
+    console.log(this.fileUpload);
   }
 
   // Preserve original property order
@@ -89,10 +78,14 @@ export class DfaAttachmentComponent implements OnInit, OnDestroy {
 
   saveAttachment(): void {
     if (this.fileUpload.status === 'VALID') {
+  
+      if (this.requiredDocumentType) this.fileUpload.get('requiredDocumentType').setValue(this.requiredDocumentType); else this.fileUpload.get('requiredDocumentType').setValue(null);
+      //this.saveFileUpload.emit(this.fileUpload.value);
+      this.fileUpload.get('id').setValue(null);
+      
       this.saveFileUpload.emit(this.fileUpload.value);
-
       this.showFileUpload = false;
-      this.initFileUploadForm();
+      //this.initFileUploadForm();
     } else {
       console.error(this.fileUpload);
       this.fileUpload.markAllAsTouched();
@@ -141,6 +134,18 @@ export class DfaAttachmentComponent implements OnInit, OnDestroy {
       this.fileUpload.get('contentType').setValue(event.type);
       this.fileUpload.get('fileSize').setValue(event.size);
       this.fileUpload.get('uploadedDate').setValue(new Date());
+
+      this.fileUpload.get('deleteFlag').setValue(false);
+      this.fileUpload.get('applicationId').setValue(this.dfaApplicationMainDataService.getApplicationId());
+      
+      this.fileUpload.get('modifiedBy').setValue("Applicant");
+      if (!this.fileUpload.get('fileType').value) {
+        if (this.fileType) 
+          this.fileUpload.get('fileType').setValue(this.fileType);
+        else this.fileUpload.get('fileType').setValue(null);
+      }
+
+      this.fileUpload.updateValueAndValidity();
     };
   }
 }

--- a/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/feature-components/dfa-application-main/dfa-application-main.component.ts
@@ -510,9 +510,9 @@ export class DFAApplicationMainComponent
           default:
             break;
         }
-        this.form$.unsubscribe();
+        if (this.form$) this.form$.unsubscribe();
         stepper.next();
-        this.form.markAllAsTouched();
+        if (this.form) this.form.markAllAsTouched();
       },
       error => {
         console.error(error);

--- a/dfa/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-application-main-forms/supporting-documents/supporting-documents.component.html
+++ b/dfa/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-application-main-forms/supporting-documents/supporting-documents.component.html
@@ -332,7 +332,7 @@
             allowedFileExtensionsList=".pdf, .doc, .docx, .png, .jpeg, .jpg, .ppt, .pptx, .xls, .xlsx"
             fileType="Financial"
             excludeFileTypes="[]"
-            (saveFileUpload)="saveRequiredForm($event)"
+            (saveFileUpload)="saveRequiredForm($event, 'directorsListingFileUpload')"
             [fileUpload]="formCreationService.fileUploadsForm.value.get('directorsListingFileUpload')"
           ></app-dfa-attachment>
           <app-loader
@@ -362,7 +362,7 @@
             allowedFileExtensionsList=".pdf, .doc, .docx, .png, .jpeg, .jpg, .ppt, .pptx, .xls, .xlsx"
             fileType="Financial"
             excludeFileTypes="[]"
-            (saveFileUpload)="saveRequiredForm($event)"
+            (saveFileUpload)="saveRequiredForm($event, 'registrationProofFileUpload')"
             [fileUpload]="formCreationService.fileUploadsForm.value.get('registrationProofFileUpload')"
           ></app-dfa-attachment>
           <app-loader
@@ -392,7 +392,7 @@
             allowedFileExtensionsList=".pdf, .doc, .docx, .png, .jpeg, .jpg, .ppt, .pptx, .xls, .xlsx"
             fileType="Financial"
             excludeFileTypes="[]"
-            (saveFileUpload)="saveRequiredForm($event)"
+            (saveFileUpload)="saveRequiredForm($event, 'structureAndPurposeFileUpload')"
             [fileUpload]="formCreationService.fileUploadsForm.value.get('structureAndPurposeFileUpload')"
           ></app-dfa-attachment>
           <app-loader

--- a/dfa/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-application-main-forms/supporting-documents/supporting-documents.component.ts
+++ b/dfa/src/UI/embc-dfa/src/app/sharedModules/forms/dfa-application-main-forms/supporting-documents/supporting-documents.component.ts
@@ -371,10 +371,11 @@ export default class SupportingDocumentsComponent implements OnInit, OnDestroy {
     }
   }
 
-  saveRequiredForm(fileUpload: FileUpload): void {
+  saveRequiredForm(fileUpload: FileUpload, fileUploadFormGroup : string): void {
     // dont allow same filename twice
     let fileUploads = this.formCreationService.fileUploadsForm.value.get('fileUploads').value;
     if (fileUploads?.find(x => x.fileName === fileUpload.fileName && x.deleteFlag !== true)) {
+      this.formCreationService.fileUploadsForm.value.get(fileUploadFormGroup).reset();
       this.warningDialog("A file with the name " + fileUpload.fileName + " has already been uploaded.");
       return;
     }
@@ -383,10 +384,12 @@ export default class SupportingDocumentsComponent implements OnInit, OnDestroy {
     fileUpload.fileData = fileUpload?.fileData?.substring(fileUpload?.fileData?.indexOf(',') + 1) // to allow upload as byte array
     if (fileUploads?.filter(x => x.requiredDocumentType === fileUpload.requiredDocumentType).length > 0) {
       this.attachmentsService.attachmentUpsertDeleteAttachment({body: fileUpload }).subscribe({
-        next: (result) => {
+        next: (fileUploadId) => {
+         fileUpload.id = fileUploadId;
           let requiredDocumentTypeFoundIndex = fileUploads.findIndex(x => x.requiredDocumentType === fileUpload.requiredDocumentType);
           fileUploads[requiredDocumentTypeFoundIndex] = fileUpload;
           this.formCreationService.fileUploadsForm.value.get('fileUploads').setValue(fileUploads);
+          this.formCreationService.fileUploadsForm.value.get(fileUploadFormGroup).reset();
           this.isLoading = false;
           this._snackBar.open('The document was successfully uploaded', 'Close', {
             horizontalPosition: 'center',
@@ -415,6 +418,7 @@ export default class SupportingDocumentsComponent implements OnInit, OnDestroy {
           if (fileUploads) fileUploads.push(fileUpload);
           else fileUploads = [fileUpload];
           this.formCreationService.fileUploadsForm.value.get('fileUploads').setValue(fileUploads);
+          this.formCreationService.fileUploadsForm.value.get(fileUploadFormGroup).reset();
           if (fileUpload.requiredDocumentType == Object.keys(this.RequiredDocumentTypes)[Object.values(this.RequiredDocumentTypes).indexOf(this.RequiredDocumentTypes.TenancyAgreement)])
             this.supportingDocumentsForm.get('hasCopyOfARentalAgreementOrLease').setValue(true);
           this.isLoading = false;


### PR DESCRIPTION
Fixed the issue fileupload form rest functionality
- Added functionality to reset the save attachment functionality
- Added null conditions for the stepper functionality
- Added new field to the savefileupload
- reset the form values in savefileupload method