### PR TITLE
D4P-280   Portal - Viewing of Advanced Payment Claims

### DIFF
--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/claim-dashboard-components/claim-decision/claim-decision.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/claim-dashboard-components/claim-decision/claim-decision.component.html
@@ -88,7 +88,9 @@
                         <span><b>Less First $1,000 - </b></span>
                     </div>
                     <div class="col-md-2">
-                        <span>CA$ {{recoveryClaim?.claim.lessFirst1000 | number: '1.2-2'}}</span>
+                        <span>
+                            {{ isAdvPayClaim ? 'N/A' : ('CA$ ' + (recoveryClaim?.claim.lessFirst1000 | number: '1.2-2')) }}
+                        </span>
                     </div>
                     <div class="col-md-2">
                         <span><b>Paid Claim Amount - </b></span>
@@ -106,10 +108,12 @@
                         <span>CA$ {{recoveryClaim?.claim.claimTotal | number: '1.2-2'}}</span>
                     </div>
                     <div class="col-md-2">
-                        <span><b>Approved Reimbursement % - </b></span>
+                    <span><b>Approved Reimbursement % - </b></span>
                     </div>
                     <div class="col-md-2">
-                        <span>{{recoveryClaim?.claim.approvedReimbursement}}</span>
+                    <span>
+                        {{ isAdvPayClaim ? 'N/A' : recoveryClaim?.claim.approvedReimbursement }}
+                    </span>
                     </div>
                     <div class="col-md-2">
                         <span><b>Paid Claim Date - </b></span>

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/claim-dashboard-components/claim-decision/claim-decision.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/claim-dashboard-components/claim-decision/claim-decision.component.ts
@@ -29,7 +29,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 export class ClaimDecisionComponent implements OnInit {
   DecisionEnum = Decision;
   ClaimTypeEnum = ClaimType;
-  
+
   recoveryClaim?: DfaClaimMain;
   recoveryClaimFormAbstract: [];
 
@@ -38,7 +38,7 @@ export class ClaimDecisionComponent implements OnInit {
   documentSummaryDataSourceFiltered = new MatTableDataSource<InvoiceExtended>();
   invoicesCount: number = 0;
   formCreationService: FormCreationService;
-  
+
   InvoiceDecisionEnum = InvoiceDecision;
 
   claimId: string | null = null;
@@ -94,7 +94,7 @@ export class ClaimDecisionComponent implements OnInit {
           this.recoveryClaim = dfaClaimMain;
 
           this.dfaClaimMainDataService.setDFAClaimMain(dfaClaimMain);
-          
+
           //this.dfaClaimMainMapping.mapDFAClaimMain(dfaClaimMain);
           console.log('Recovery Claim:', this.recoveryClaim);
         },
@@ -139,7 +139,7 @@ export class ClaimDecisionComponent implements OnInit {
           this.documentSummaryDataSourceFiltered.data = this.documentSummaryDataSource.data;
           this.invoicesCount = this.documentSummaryDataSource.data.length;
 
-          
+
 
           // this.formCreationService.recoveryClaimForm.value
           //   .get('invoices')
@@ -169,7 +169,7 @@ export class ClaimDecisionComponent implements OnInit {
       } else {
         this.dfaClaimMainDataService.setInvoiceId(null);
       }
-  
+
       this.dialog
         .open(InvoiceComponent, {
           data: {
@@ -193,13 +193,13 @@ export class ClaimDecisionComponent implements OnInit {
 
   canAppealClaims(applItem: DfaClaimMain): boolean {
     // Check if the claim is eligible for appeal based on its status and decision
-    return applItem?.claim.claimDecision 
+    return applItem?.claim.claimDecision
       && (
-          applItem?.claim.claimDecision.toLowerCase() === this.DecisionEnum.ApprovedWithExclusions.toLowerCase() 
+          applItem?.claim.claimDecision.toLowerCase() === this.DecisionEnum.ApprovedWithExclusions.toLowerCase()
           || applItem?.claim.claimDecision.toLowerCase() === this.DecisionEnum.Ineligible.toLowerCase()
         )
       && (applItem?.claim.isAdjustmentClaim !== true && applItem?.claim.claimType !== this.ClaimTypeEnum.AdvancedPayment)
-      && this.remainingDays(applItem) > 0; 
+      && this.remainingDays(applItem) > 0;
   }
 
   remainingDays(appItem: DfaClaimMain): number {
@@ -211,6 +211,10 @@ export class ClaimDecisionComponent implements OnInit {
     let endDate = new Date(endDateStr);
     endDate.setDate(endDate.getDate() + 60);  // add 60 days
     return Math.round((endDate.getTime() - new Date().getTime()) / oneDay);
+  }
+
+  get isAdvPayClaim(): boolean {
+    return this.recoveryClaim?.claim?.claimNumber?.startsWith('ADVPAY');
   }
 
 }


### PR DESCRIPTION
This update modifies the summary display logic for advance payment claims. 

If a claim is identified as an advance payment, the following fields will now display as "N/A":
- Less First $1,000
- Approved Reimbursement %

<img width="1417" height="583" alt="Screenshot 2025-07-17 115844" src="https://github.com/user-attachments/assets/0ec5907f-bb53-4826-a42b-972038ffac25" />

[Story](https://emcr.atlassian.net/browse/D4P-280)