### PR TITLE
D4P-162: Project appeals button visibility rules

### DIFF
--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.html
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.html
@@ -257,27 +257,42 @@
             </table>
           </div>
         </div>
-        <div class="col-md-12" style="display: flex; justify-content: flex-end; padding-right: 32px;">
+      </div>
+      <div [featureEnabled]="'useAppeals'" *ngIf="canAppeal(applItem)">
+        <div *ngIf="applItem.activeStage" class="col-md-12" style="display: flex; justify-content: flex-end; padding-right: 32px;">
           <div class="button-column">
             <button
-              [class]="appealButtonClass(applItem)"
-              (click)="appealDecision(applItem)"
-              type="button"
-              [disabled]="!canAppeal(applItem)"
-              [title]="appealButtonTitle(applItem)"
-            >
-              {{ applItem.isSubmitted ? "Appeal Details" : "Appeal Decision" }}
+                class="application-button"
+                (click)="appealDecision(applItem)"
+                type="button"
+              >
+                 Appeal Details
             </button>
           </div>
         </div>
-        <div
-          *ngIf="canAppeal(applItem)"
-          class="col-md-12"
-          style="display: flex; justify-content: flex-end; padding: 10px 32px 0 0;"
-        >
-          <span>
-            Project Approval decision can be appealed for {{ remainingDays(applItem) }} days
-          </span>
+        <div [featureEnabled]="'useAppeals'" *ngIf="!applItem.activeStage">
+          <div class="col-md-12" style="display: flex; justify-content: flex-end; padding-right: 32px;">
+            <div class="button-column">
+              <button
+                  [class]="appealButtonClass(applItem)"
+                  (click)="appealDecision(applItem)"
+                  type="button"
+                  [disabled]="!appealHasRemainingDays(applItem)"
+                  [title]="appealButtonTitle(applItem)"
+                >
+                  Appeal Decision
+              </button>
+            </div>
+          </div>
+          <div
+            *ngIf="appealHasRemainingDays(applItem)"
+            class="col-md-12"
+            style="display: flex; justify-content: flex-end; padding: 10px 32px 0 0;"
+          >
+            <span>
+              Project Approval decision can be appealed for {{ remainingDays(applItem) }} days
+            </span>
+          </div>
         </div>
       </div>
     </mat-card>

--- a/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.ts
+++ b/dfa-public/src/UI/embc-dfa/src/app/sharedModules/project-dashboard-components/project/project.component.ts
@@ -438,8 +438,11 @@ export class DfaDashProjectComponent implements OnInit {
   }
 
   canAppeal(project: CurrentProject): boolean {
-    return project.projectDecision && (project.projectDecision.toLowerCase() === 'approved with exclusions' || project.projectDecision.toLowerCase() === 'ineligible')
-      && this.remainingDays(project) > 0;
+    return project.projectDecision && (project.projectDecision.toLowerCase() === 'approved with exclusions' || project.projectDecision.toLowerCase() === 'ineligible');
+  }
+
+  appealHasRemainingDays(project: CurrentProject): boolean {
+    return this.remainingDays(project) >= 0;
   }
 
   remainingDays(project: CurrentProject): number {
@@ -458,7 +461,7 @@ export class DfaDashProjectComponent implements OnInit {
   }
 
   appealButtonClass(project: CurrentProject): string {
-    return this.canAppeal(project) ? 'application-button' : 'disabled-button';
+    return this.appealHasRemainingDays(project) ? 'application-button' : 'disabled-button';
   }
 
   appealDecision(): void {


### PR DESCRIPTION
https://emcr.atlassian.net/browse/D4P-162
- Fixed issue were "Appeal Decision" Button was not appearing unless an appeal existed 
- Button now shows "Appeal Details" when appeal exists and does not show days remaining text.
- Button is now not visible  when not in stage "ineligible" or approved with exclusions
- Button is now disabled when no remaining days to appeal