### PR TITLE
DFA-80: Portal: Read-only fields need more text colour contrast

### DIFF
--- a/dfa-public/src/UI/embc-dfa/src/styles/styles.scss
+++ b/dfa-public/src/UI/embc-dfa/src/styles/styles.scss
@@ -416,3 +416,43 @@ mat-card {
 .versions-table {
   width: 100%;
 }
+
+/* Overwrite default disabled text style to improve legibility - START */
+
+/* matInput: text when disabled */
+.mat-mdc-form-field.mat-form-field-disabled .mdc-text-field--disabled .mdc-text-field__input {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* mat-form-field: label when disabled */
+.mat-mdc-form-field.mat-form-field-disabled .mdc-floating-label {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* mat-select: selected text + label when disabled */
+.mat-mdc-select.mat-mdc-select-disabled {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* mat-option: label when disabled */
+.mat-mdc-option.mdc-list-item--disabled,
+.mat-mdc-option.mat-mdc-option-disabled {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* mat-radio-button: label when disabled */
+.mat-mdc-radio-button.mat-mdc-radio-disabled .mdc-label {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* mat-checkbox: label when disabled */
+.mat-mdc-checkbox.mat-mdc-checkbox-disabled .mdc-label {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* input placeholder text (to match the disabled text) */
+.mat-mdc-input-element::placeholder {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* Overwrite default disabled text style to improve legibility - END */

--- a/dfa/src/UI/embc-dfa/src/styles/styles.scss
+++ b/dfa/src/UI/embc-dfa/src/styles/styles.scss
@@ -685,3 +685,43 @@ mat-card {
 }
 
 // End Timeline
+
+/* Overwrite default disabled text style to improve legibility - START */
+
+/* matInput: text when disabled */
+.mat-mdc-form-field.mat-form-field-disabled .mdc-text-field--disabled .mdc-text-field__input {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* mat-form-field: label when disabled */
+.mat-mdc-form-field.mat-form-field-disabled .mdc-floating-label {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* mat-select: selected text + label when disabled */
+.mat-mdc-select.mat-mdc-select-disabled {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* mat-option: label when disabled */
+.mat-mdc-option.mdc-list-item--disabled,
+.mat-mdc-option.mat-mdc-option-disabled {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* mat-radio-button: label when disabled */
+.mat-mdc-radio-button.mat-mdc-radio-disabled .mdc-label {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* mat-checkbox: label when disabled */
+.mat-mdc-checkbox.mat-mdc-checkbox-disabled .mdc-label {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* input placeholder text (to match the disabled text) */
+.mat-mdc-input-element::placeholder {
+  color: rgba(0, 0, 0, 0.65) !important;
+}
+
+/* Overwrite default disabled text style to improve legibility - END */


### PR DESCRIPTION
## Ticket

https://emcr.atlassian.net/browse/DFA-80

## Changes

Added new scss to `styles.scss` to overwrite the default disabled text color/opacity to improve legibility.

Added the same styles to both public and private. The styles should only impact disabled text color.

## Before vs After
<img width="1328" height="1170" alt="DFA-80_Before" src="https://github.com/user-attachments/assets/65fb13d1-527b-47b4-b077-81793b1ce12d" />
<img width="1329" height="1174" alt="DFA-80_After" src="https://github.com/user-attachments/assets/eb9109c6-8870-4c8f-b395-161faba9e607" />

